### PR TITLE
Don't dispatch reset complete on boot/update/remove

### DIFF
--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityExtension.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityExtension.java
@@ -191,7 +191,7 @@ class IdentityExtension extends Extension {
      */
     void handleIdentityRequest(final Event event) {
         if (!canProcessEvents()) {
-            MobileCore.log(LoggingMode.DEBUG, LOG_TAG, "Unable to process request reset event. canProcessEvents returned false.");
+            MobileCore.log(LoggingMode.DEBUG, LOG_TAG, "Unable to process request identities event. canProcessEvents returned false.");
             return;
         }
 
@@ -225,6 +225,21 @@ class IdentityExtension extends Extension {
         }
         state.resetIdentifiers();
         shareIdentityXDMSharedState(event);
+
+        // dispatch reset complete event
+        final Event responseEvent = new Event.Builder(IdentityConstants.EventNames.RESET_IDENTITIES_COMPLETE,
+                IdentityConstants.EventType.EDGE_IDENTITY,
+                IdentityConstants.EventSource.RESET_COMPLETE).build();
+
+        MobileCore.dispatchEvent(responseEvent, new ExtensionErrorCallback<ExtensionError>() {
+            @Override
+            public void error(ExtensionError extensionError) {
+                MobileCore.log(LoggingMode.DEBUG, LOG_TAG, "Failed to dispatch Edge Identity reset response event for event " +
+                        event.getUniqueIdentifier() +
+                        " with error " +
+                        extensionError.getErrorName());
+            }
+        });
     }
 
     /**
@@ -269,21 +284,6 @@ class IdentityExtension extends Extension {
         };
 
         extensionApi.setXDMSharedEventState(state.getIdentityProperties().toXDMData(false), event, errorCallback);
-
-        // dispatch response event
-        final Event responseEvent = new Event.Builder(IdentityConstants.EventNames.RESET_IDENTITIES_COMPLETE,
-                IdentityConstants.EventType.EDGE_IDENTITY,
-                IdentityConstants.EventSource.RESET_COMPLETE).build();
-
-        MobileCore.dispatchEvent(responseEvent, new ExtensionErrorCallback<ExtensionError>() {
-            @Override
-            public void error(ExtensionError extensionError) {
-                MobileCore.log(LoggingMode.DEBUG, LOG_TAG, "Failed to dispatch Edge Identity reset response event for event " +
-                        event.getUniqueIdentifier() +
-                        " with error " +
-                        extensionError.getErrorName());
-            }
-        });
     }
 
     /**

--- a/code/edgeidentity/src/test/java/com/adobe/marketing/mobile/edge/identity/IdentityExtensionTests.java
+++ b/code/edgeidentity/src/test/java/com/adobe/marketing/mobile/edge/identity/IdentityExtensionTests.java
@@ -263,6 +263,12 @@ public class IdentityExtensionTests {
         verify(mockExtensionApi, times(1)).setXDMSharedEventState(sharedStateCaptor.capture(), eq(event), any(ExtensionErrorCallback.class));
         Map<String, Object> sharedState = sharedStateCaptor.getValue();
         assertEquals("1234", flattenMap(sharedState).get("identityMap.ECID[1].id")); // Legacy ECID is set as a secondary ECID
+
+        final ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+        // verify no event dispatched
+        PowerMockito.verifyStatic(MobileCore.class, Mockito.times(0));
+        MobileCore.dispatchEvent(eventCaptor.capture(), any(ExtensionErrorCallback.class));
+        assertTrue(eventCaptor.getAllValues().isEmpty());
     }
 
     @Test
@@ -374,7 +380,7 @@ public class IdentityExtensionTests {
         );
         final ArgumentCaptor<Map> sharedStateCaptor = ArgumentCaptor.forClass(Map.class);
         final ArgumentCaptor<String> persistenceValueCaptor = ArgumentCaptor.forClass(String.class);
-
+        final ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
 
         // test
         Event updateIdentityEvent = buildUpdateIdentityRequest(identityXDM);
@@ -386,6 +392,11 @@ public class IdentityExtensionTests {
         assertEquals("secretID", sharedState.get("identityMap.UserId[0].id"));
         assertEquals("ambiguous", sharedState.get("identityMap.UserId[0].authenticatedState"));
         assertEquals("false", sharedState.get("identityMap.UserId[0].primary"));
+
+        // verify no event dispatched
+        PowerMockito.verifyStatic(MobileCore.class, Mockito.times(0));
+        MobileCore.dispatchEvent(eventCaptor.capture(), any(ExtensionErrorCallback.class));
+        assertTrue(eventCaptor.getAllValues().isEmpty());
 
         // verify persistence
         verify(mockSharedPreferenceEditor, times(2)).putString(eq(IdentityConstants.DataStoreKey.IDENTITY_PROPERTIES), persistenceValueCaptor.capture());
@@ -479,6 +490,8 @@ public class IdentityExtensionTests {
 
         final ArgumentCaptor<Map> sharedStateCaptor = ArgumentCaptor.forClass(Map.class);
         final ArgumentCaptor<String> persistenceValueCaptor = ArgumentCaptor.forClass(String.class);
+        final ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+
         extension = new IdentityExtension(mockExtensionApi);
 
         // test
@@ -494,6 +507,10 @@ public class IdentityExtensionTests {
         assertNull(sharedState.get("identityMap.UserId[0].id"));
         assertEquals("token", sharedState.get("identityMap.PushId[0].id"));
 
+        // verify no event dispatched
+        PowerMockito.verifyStatic(MobileCore.class, Mockito.times(0));
+        MobileCore.dispatchEvent(eventCaptor.capture(), any(ExtensionErrorCallback.class));
+        assertTrue(eventCaptor.getAllValues().isEmpty());
 
         // verify persistence
         verify(mockSharedPreferenceEditor, times(2)).putString(eq(IdentityConstants.DataStoreKey.IDENTITY_PROPERTIES), persistenceValueCaptor.capture());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Our common shareIdentityXDMSharedState was originally only used in the reset event handling so it also included the event dispatching to indicate the reset was complete. After some recent updates, the shareIdentityXDMSharedState method is now used when updating/removing/booting which was causing reset complete events to be dispatched.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
