### PR TITLE
Set mock network service for functional tests

### DIFF
--- a/code/edgeidentity/src/androidTest/java/com/adobe/marketing/mobile/MockNetworkService.java
+++ b/code/edgeidentity/src/androidTest/java/com/adobe/marketing/mobile/MockNetworkService.java
@@ -1,0 +1,73 @@
+/*
+  Copyright 2021 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile;
+
+import com.adobe.marketing.mobile.services.HttpConnecting;
+import com.adobe.marketing.mobile.services.NetworkCallback;
+import com.adobe.marketing.mobile.services.NetworkRequest;
+import com.adobe.marketing.mobile.services.Networking;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+/**
+ * Mock network service used by MobileCore for functional test cases.
+ * This network service returns '200' HttpConnection responses for every request.
+ */
+class MockNetworkService implements Networking {
+	private static String TAG = "MockNetworkService";
+
+	private static HttpConnecting dummyConnection = new HttpConnecting() {
+		@Override
+		public InputStream getInputStream() {
+			return new ByteArrayInputStream("{}".getBytes());
+		}
+
+		@Override
+		public InputStream getErrorStream() {
+			return null;
+		}
+
+		@Override
+		public int getResponseCode() {
+			return 200;
+		}
+
+		@Override
+		public String getResponseMessage() {
+			return null;
+		}
+
+		@Override
+		public String getResponsePropertyValue(String s) {
+			return null;
+		}
+
+		@Override
+		public void close() {
+
+		}
+	};
+
+	@Override
+	public void connectAsync(NetworkRequest networkRequest, NetworkCallback networkCallback) {
+		if (networkRequest == null) {
+			return;
+		}
+
+		MobileCore.log(LoggingMode.DEBUG, TAG, "Received async request '" + networkRequest.getUrl() + "', ignoring.");
+
+		if (networkCallback != null) {
+			networkCallback.call(dummyConnection);
+		}
+	}
+}

--- a/code/edgeidentity/src/androidTest/java/com/adobe/marketing/mobile/TestHelper.java
+++ b/code/edgeidentity/src/androidTest/java/com/adobe/marketing/mobile/TestHelper.java
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeUnit;
 
 import com.adobe.marketing.mobile.MonitorExtension.EventSpec;
 import com.adobe.marketing.mobile.edge.identity.ADBCountDownLatch;
+import com.adobe.marketing.mobile.services.ServiceProvider;
 
 import androidx.test.platform.app.InstrumentationRegistry;
 
@@ -76,6 +77,7 @@ public class TestHelper {
 						defaultApplication = Instrumentation.newApplication(CustomApplication.class, context);
 					}
 
+					ServiceProvider.getInstance().setNetworkService(new MockNetworkService()); // set mock network service for testing
 					MobileCore.setLogLevel(LoggingMode.VERBOSE);
 					MobileCore.setApplication(defaultApplication);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
This extension does not execute network requests, but a mock network service is required for integration testing with Identity direct extension. Using a mock network service allows for immediate network connection return and use of dummy server names.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

This change was required due to intermittent test failures caused by in progress network tasks observed during the cleanup between tests.
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Android test now pass consistently

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
