### PR TITLE
Test App Update for Ad ID Edge Identity Features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ ci/
 # IntelliJ
 *.iml
 **/.idea/
+
+# Secrets
+**/*/values/secrets.xml

--- a/code/app/build.gradle
+++ b/code/app/build.gradle
@@ -56,6 +56,7 @@ dependencies {
     implementation project(':edgeidentity')
     implementation 'com.adobe.marketing.mobile:core:1+'
     implementation 'com.adobe.marketing.mobile:identity:1+'
+    implementation 'com.adobe.marketing.mobile:edgeconsent:1.+'
     implementation('com.adobe.marketing.mobile:edge:1+') {
         exclude group: 'com.adobe.marketing.mobile', module:'edgeidentity'
     }

--- a/code/app/build.gradle
+++ b/code/app/build.gradle
@@ -20,6 +20,7 @@ android {
         targetSdkVersion 31
         versionCode 1
         versionName "1.0"
+        multiDexEnabled = true
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -65,4 +66,5 @@ dependencies {
     implementation("com.google.android.gms:play-services-ads-lite:20.6.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.0")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.0-alpha06")
+    implementation("androidx.multidex:multidex:2.0.1")
 }

--- a/code/app/build.gradle
+++ b/code/app/build.gradle
@@ -20,6 +20,8 @@ android {
         targetSdkVersion 31
         versionCode 1
         versionName "1.0"
+        multiDexEnabled = true
+
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -61,8 +63,9 @@ dependencies {
     }
     implementation 'com.adobe.marketing.mobile:assurance:1+'
 
-    implementation("com.google.guava:guava:31.1-android")
     implementation("com.google.android.gms:play-services-ads-lite:20.6.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.0")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.0-alpha06")
+    implementation("androidx.multidex:multidex:2.0.1")
+
 }

--- a/code/app/build.gradle
+++ b/code/app/build.gradle
@@ -20,8 +20,6 @@ android {
         targetSdkVersion 31
         versionCode 1
         versionName "1.0"
-        multiDexEnabled = true
-
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -66,6 +64,4 @@ dependencies {
     implementation("com.google.android.gms:play-services-ads-lite:20.6.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.0")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.0-alpha06")
-    implementation("androidx.multidex:multidex:2.0.1")
-
 }

--- a/code/app/build.gradle
+++ b/code/app/build.gradle
@@ -12,12 +12,12 @@ spotless {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         applicationId "com.adobe.marketing.edge.identity.app"
         minSdkVersion 19
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
 
@@ -60,4 +60,9 @@ dependencies {
         exclude group: 'com.adobe.marketing.mobile', module:'edgeidentity'
     }
     implementation 'com.adobe.marketing.mobile:assurance:1+'
+
+    implementation("com.google.guava:guava:31.1-android")
+    implementation("com.google.android.gms:play-services-ads-lite:20.6.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.0")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.0-alpha06")
 }

--- a/code/app/src/main/AndroidManifest.xml
+++ b/code/app/src/main/AndroidManifest.xml
@@ -15,13 +15,18 @@
         <activity
             android:name="com.adobe.marketing.edge.identity.app.MainActivity"
             android:label="@string/app_name"
-            android:theme="@style/AppTheme.NoActionBar">
+            android:theme="@style/AppTheme.NoActionBar"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <meta-data
+            android:name="com.google.android.gms.ads.APPLICATION_ID"
+            android:value="ca-app-pub-3940256099942544~3347511713"/>
+
     </application>
 
 </manifest>

--- a/code/app/src/main/AndroidManifest.xml
+++ b/code/app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
-        android:name="com.adobe.marketing.edge.identity.app.EdgeIdentityApplication"
+        android:name="androidx.multidex.MultiDexApplication"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"

--- a/code/app/src/main/AndroidManifest.xml
+++ b/code/app/src/main/AndroidManifest.xml
@@ -25,7 +25,7 @@
         </activity>
         <meta-data
             android:name="com.google.android.gms.ads.APPLICATION_ID"
-            android:value="ca-app-pub-3940256099942544~3347511713"/>
+            android:value="@string/gms_ads_app_id"/>
 
     </application>
 

--- a/code/app/src/main/AndroidManifest.xml
+++ b/code/app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
-        android:name="androidx.multidex.MultiDexApplication"
+        android:name="com.adobe.marketing.edge.identity.app.EdgeIdentityApplication"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"

--- a/code/app/src/main/java/com/adobe/marketing/edge/identity/app/EdgeIdentityApplication.kt
+++ b/code/app/src/main/java/com/adobe/marketing/edge/identity/app/EdgeIdentityApplication.kt
@@ -16,6 +16,7 @@ import com.adobe.marketing.mobile.Assurance
 import com.adobe.marketing.mobile.Edge
 import com.adobe.marketing.mobile.LoggingMode
 import com.adobe.marketing.mobile.MobileCore
+import com.adobe.marketing.mobile.edge.consent.Consent
 import com.adobe.marketing.mobile.edge.identity.Identity
 
 class EdgeIdentityApplication : Application() {
@@ -29,6 +30,7 @@ class EdgeIdentityApplication : Application() {
         MobileCore.setApplication(this)
         MobileCore.setLogLevel(LoggingMode.VERBOSE)
 
+        Consent.registerExtension()
         Identity.registerExtension()
         Edge.registerExtension()
         Assurance.registerExtension()

--- a/code/app/src/main/java/com/adobe/marketing/edge/identity/app/model/SharedViewModel.kt
+++ b/code/app/src/main/java/com/adobe/marketing/edge/identity/app/model/SharedViewModel.kt
@@ -124,6 +124,10 @@ class SharedViewModel : ViewModel() {
             Log.d("Shared_View_Model", "Thread working in ${Thread.currentThread().name}")
             try {
                 val idInfo = AdvertisingIdClient.getAdvertisingIdInfo(applicationContext)
+                if (idInfo.isLimitAdTrackingEnabled) {
+                    Log.d("Shared_View_Model", "Limit Ad Tracking is enabled by the user, cannot process the advertising identifier")
+                    return@launch
+                }
 
                 Log.d("Shared_View_Model", "AdID: ${idInfo.id}")
                 MobileCore.setAdvertisingIdentifier(idInfo.id)

--- a/code/app/src/main/java/com/adobe/marketing/edge/identity/app/model/SharedViewModel.kt
+++ b/code/app/src/main/java/com/adobe/marketing/edge/identity/app/model/SharedViewModel.kt
@@ -11,10 +11,20 @@
 
 package com.adobe.marketing.edge.identity.app.model
 
+import android.content.Context
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.adobe.marketing.mobile.MobileCore
 import com.adobe.marketing.mobile.edge.identity.AuthenticatedState
+import com.google.android.gms.ads.identifier.AdvertisingIdClient
+import com.google.android.gms.common.GooglePlayServicesNotAvailableException
+import com.google.android.gms.common.GooglePlayServicesRepairableException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.io.IOException
 
 class SharedViewModel : ViewModel() {
     companion object {
@@ -23,6 +33,8 @@ class SharedViewModel : ViewModel() {
         const val IDENTITY_IS_REGISTERED_STRING = "Identity is registered"
         const val EDGE_IDENTITY_IS_REGISTERED_STRING = "Edge Identity is registered"
     }
+
+
 
     // Models for Get Identities View
 
@@ -49,6 +61,9 @@ class SharedViewModel : ViewModel() {
 
     // Models for Update Identities View
 
+    private val _adId = MutableLiveData<String>("")
+    val adId: LiveData<String> = _adId
+
     private val _identifier = MutableLiveData<String>("")
     val identifier: LiveData<String> = _identifier
 
@@ -63,6 +78,13 @@ class SharedViewModel : ViewModel() {
 
     private val _authenticatedStateId = MutableLiveData<Int>(null)
     val authenticatedStateId: LiveData<Int> = _authenticatedStateId
+
+    fun setAdId(value: String) {
+        if (_adId.value == value) {
+            return
+        }
+        _adId.value = value
+    }
 
     fun setIdentifier(value: String) {
         if (_identifier.value == value) {
@@ -97,6 +119,24 @@ class SharedViewModel : ViewModel() {
             return
         }
         _authenticatedStateId.value = value
+    }
+
+    fun getGAID(applicationContext: Context) {
+        viewModelScope.launch(Dispatchers.Default) {
+            Log.d("Shared_View_Model", "Thread working in ${Thread.currentThread().name}")
+            try {
+                val idInfo = AdvertisingIdClient.getAdvertisingIdInfo(applicationContext)
+
+                Log.d("Shared_View_Model", "AdID: ${idInfo.id}")
+                MobileCore.setAdvertisingIdentifier(idInfo.id)
+            } catch (e: GooglePlayServicesNotAvailableException) {
+                e.printStackTrace()
+            } catch (e: GooglePlayServicesRepairableException) {
+                e.printStackTrace()
+            } catch (e: IOException) {
+                e.printStackTrace()
+            }
+        }
     }
 
     // Models for Multiple Identities View

--- a/code/app/src/main/java/com/adobe/marketing/edge/identity/app/model/SharedViewModel.kt
+++ b/code/app/src/main/java/com/adobe/marketing/edge/identity/app/model/SharedViewModel.kt
@@ -121,7 +121,6 @@ class SharedViewModel : ViewModel() {
 
     fun getGAID(applicationContext: Context) {
         viewModelScope.launch(Dispatchers.Default) {
-            Log.d("Shared_View_Model", "Thread working in ${Thread.currentThread().name}")
             try {
                 val idInfo = AdvertisingIdClient.getAdvertisingIdInfo(applicationContext)
                 if (idInfo.isLimitAdTrackingEnabled) {

--- a/code/app/src/main/java/com/adobe/marketing/edge/identity/app/model/SharedViewModel.kt
+++ b/code/app/src/main/java/com/adobe/marketing/edge/identity/app/model/SharedViewModel.kt
@@ -32,6 +32,7 @@ class SharedViewModel : ViewModel() {
         const val REGISTER_EDGE_IDENTITY_STRING = "Register Edge Identity"
         const val IDENTITY_IS_REGISTERED_STRING = "Identity is registered"
         const val EDGE_IDENTITY_IS_REGISTERED_STRING = "Edge Identity is registered"
+        const val LOG_TAG = "Shared_View_Model"
     }
 
     // Models for Get Identities View
@@ -124,19 +125,19 @@ class SharedViewModel : ViewModel() {
             try {
                 val idInfo = AdvertisingIdClient.getAdvertisingIdInfo(applicationContext)
                 if (idInfo.isLimitAdTrackingEnabled) {
-                    Log.d("Shared_View_Model", "Limit Ad Tracking is enabled by the user, setting ad ID to \"\"")
+                    Log.d(LOG_TAG, "Limit Ad Tracking is enabled by the user, setting ad ID to \"\"")
                     MobileCore.setAdvertisingIdentifier("")
                     return@launch
                 }
 
-                Log.d("Shared_View_Model", "AdID: ${idInfo.id}")
+                Log.d(LOG_TAG, "AdID: ${idInfo.id}")
                 MobileCore.setAdvertisingIdentifier(idInfo.id)
             } catch (e: GooglePlayServicesNotAvailableException) {
-                Log.d("Shared_View_Model", "GooglePlayServicesNotAvailableException while retrieving the advertising identifier ${e.localizedMessage}")
+                Log.d(LOG_TAG, "GooglePlayServicesNotAvailableException while retrieving the advertising identifier ${e.localizedMessage}")
             } catch (e: GooglePlayServicesRepairableException) {
-                Log.d("Shared_View_Model", "GooglePlayServicesRepairableException while retrieving the advertising identifier ${e.localizedMessage}")
+                Log.d(LOG_TAG, "GooglePlayServicesRepairableException while retrieving the advertising identifier ${e.localizedMessage}")
             } catch (e: IOException) {
-                Log.d("Shared_View_Model", "IOException while retrieving the advertising identifier ${e.localizedMessage}")
+                Log.d(LOG_TAG, "IOException while retrieving the advertising identifier ${e.localizedMessage}")
             }
         }
     }

--- a/code/app/src/main/java/com/adobe/marketing/edge/identity/app/model/SharedViewModel.kt
+++ b/code/app/src/main/java/com/adobe/marketing/edge/identity/app/model/SharedViewModel.kt
@@ -132,11 +132,11 @@ class SharedViewModel : ViewModel() {
                 Log.d("Shared_View_Model", "AdID: ${idInfo.id}")
                 MobileCore.setAdvertisingIdentifier(idInfo.id)
             } catch (e: GooglePlayServicesNotAvailableException) {
-                e.printStackTrace()
+                Log.d("Shared_View_Model", "GooglePlayServicesNotAvailableException while retrieving the advertising identifier ${e.localizedMessage}")
             } catch (e: GooglePlayServicesRepairableException) {
-                e.printStackTrace()
+                Log.d("Shared_View_Model", "GooglePlayServicesRepairableException while retrieving the advertising identifier ${e.localizedMessage}")
             } catch (e: IOException) {
-                e.printStackTrace()
+                Log.d("Shared_View_Model", "IOException while retrieving the advertising identifier ${e.localizedMessage}")
             }
         }
     }

--- a/code/app/src/main/java/com/adobe/marketing/edge/identity/app/model/SharedViewModel.kt
+++ b/code/app/src/main/java/com/adobe/marketing/edge/identity/app/model/SharedViewModel.kt
@@ -125,7 +125,8 @@ class SharedViewModel : ViewModel() {
             try {
                 val idInfo = AdvertisingIdClient.getAdvertisingIdInfo(applicationContext)
                 if (idInfo.isLimitAdTrackingEnabled) {
-                    Log.d("Shared_View_Model", "Limit Ad Tracking is enabled by the user, cannot process the advertising identifier")
+                    Log.d("Shared_View_Model", "Limit Ad Tracking is enabled by the user, setting ad ID to \"\"")
+                    MobileCore.setAdvertisingIdentifier("")
                     return@launch
                 }
 

--- a/code/app/src/main/java/com/adobe/marketing/edge/identity/app/model/SharedViewModel.kt
+++ b/code/app/src/main/java/com/adobe/marketing/edge/identity/app/model/SharedViewModel.kt
@@ -34,8 +34,6 @@ class SharedViewModel : ViewModel() {
         const val EDGE_IDENTITY_IS_REGISTERED_STRING = "Edge Identity is registered"
     }
 
-
-
     // Models for Get Identities View
 
     private val _ecidText = MutableLiveData<String>("")

--- a/code/app/src/main/java/com/adobe/marketing/edge/identity/app/ui/CustomIdentityFragment.kt
+++ b/code/app/src/main/java/com/adobe/marketing/edge/identity/app/ui/CustomIdentityFragment.kt
@@ -16,17 +16,14 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Button
-import android.widget.CheckBox
-import android.widget.EditText
-import android.widget.RadioButton
-import android.widget.RadioGroup
+import android.widget.*
 import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import com.adobe.marketing.edge.identity.app.R
 import com.adobe.marketing.edge.identity.app.model.SharedViewModel
 import com.adobe.marketing.mobile.MobileCore
+import com.adobe.marketing.mobile.edge.consent.Consent
 import com.adobe.marketing.mobile.edge.identity.AuthenticatedState
 import com.adobe.marketing.mobile.edge.identity.Identity
 import com.adobe.marketing.mobile.edge.identity.IdentityItem
@@ -215,6 +212,12 @@ class CustomIdentityFragment : Fragment() {
                     // library to perform any required ads use cases.
                 }
                  */
+            }
+        }
+
+        root.findViewById<Button>(R.id.btn_get_consents).setOnClickListener {
+            Consent.getConsents { consents ->
+                Log.d("Custom_Identity_Fragment", "Got Consents: $consents")
             }
         }
 

--- a/code/app/src/main/java/com/adobe/marketing/edge/identity/app/ui/CustomIdentityFragment.kt
+++ b/code/app/src/main/java/com/adobe/marketing/edge/identity/app/ui/CustomIdentityFragment.kt
@@ -16,7 +16,11 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.*
+import android.widget.Button
+import android.widget.CheckBox
+import android.widget.EditText
+import android.widget.RadioButton
+import android.widget.RadioGroup
 import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels

--- a/code/app/src/main/java/com/adobe/marketing/edge/identity/app/ui/CustomIdentityFragment.kt
+++ b/code/app/src/main/java/com/adobe/marketing/edge/identity/app/ui/CustomIdentityFragment.kt
@@ -42,6 +42,7 @@ class CustomIdentityFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
+        val LOG_TAG = "Custom_Identity_Fragment"
         val sharedViewModel by activityViewModels<SharedViewModel>()
 
         val root = inflater.inflate(R.layout.fragment_custom_identity, container, false)
@@ -115,7 +116,7 @@ class CustomIdentityFragment : Fragment() {
         // please see the project Documentation -> AEPEdgeIdentity.md : Test App -> GAID Implementation
         root.findViewById<Button>(R.id.btn_get_gaid).setOnClickListener {
             val context = context
-            Log.d("Custom_Identity_Fragment", "context: $context, appContext: ${context?.applicationContext}")
+            Log.d(LOG_TAG, "context: $context, appContext: ${context?.applicationContext}")
             if (context != null) {
                 // Implementation for google play services ads
                 // Logic implemented in ViewModel to leverage managed Kotlin coroutine scope from lifecycle-viewmodel-ktx
@@ -127,18 +128,18 @@ class CustomIdentityFragment : Fragment() {
         }
 
         root.findViewById<Button>(R.id.btn_set_ad_id_null).setOnClickListener {
-            Log.d("Custom_Identity_Fragment", "Setting advertising identifier to: null")
+            Log.d(LOG_TAG, "Setting advertising identifier to: null")
             MobileCore.setAdvertisingIdentifier(null)
         }
 
         root.findViewById<Button>(R.id.btn_set_ad_id_all_zeros).setOnClickListener {
-            Log.d("Custom_Identity_Fragment", "Setting advertising identifier to: 00000000-0000-0000-0000-000000000000")
+            Log.d(LOG_TAG, "Setting advertising identifier to: 00000000-0000-0000-0000-000000000000")
             MobileCore.setAdvertisingIdentifier("00000000-0000-0000-0000-000000000000")
         }
 
         root.findViewById<Button>(R.id.btn_get_consents).setOnClickListener {
             Consent.getConsents { consents ->
-                Log.d("Custom_Identity_Fragment", "Got Consents: $consents")
+                Log.d(LOG_TAG, "Got Consents: $consents")
             }
         }
 

--- a/code/app/src/main/java/com/adobe/marketing/edge/identity/app/ui/CustomIdentityFragment.kt
+++ b/code/app/src/main/java/com/adobe/marketing/edge/identity/app/ui/CustomIdentityFragment.kt
@@ -35,8 +35,7 @@ import com.adobe.marketing.mobile.edge.identity.Identity
 import com.adobe.marketing.mobile.edge.identity.IdentityItem
 import com.adobe.marketing.mobile.edge.identity.IdentityMap
 import com.google.android.gms.ads.identifier.AdvertisingIdClient
-import com.google.common.util.concurrent.FutureCallback
-import com.google.common.util.concurrent.Futures.addCallback
+
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch

--- a/code/app/src/main/java/com/adobe/marketing/edge/identity/app/ui/CustomIdentityFragment.kt
+++ b/code/app/src/main/java/com/adobe/marketing/edge/identity/app/ui/CustomIdentityFragment.kt
@@ -215,6 +215,16 @@ class CustomIdentityFragment : Fragment() {
             }
         }
 
+        root.findViewById<Button>(R.id.btn_set_ad_id_null).setOnClickListener {
+            Log.d("Custom_Identity_Fragment", "Setting advertising identifier to: null")
+            MobileCore.setAdvertisingIdentifier(null)
+        }
+
+        root.findViewById<Button>(R.id.btn_set_ad_id_all_zeros).setOnClickListener {
+            Log.d("Custom_Identity_Fragment", "Setting advertising identifier to: 00000000-0000-0000-0000-000000000000")
+            MobileCore.setAdvertisingIdentifier("00000000-0000-0000-0000-000000000000")
+        }
+
         root.findViewById<Button>(R.id.btn_get_consents).setOnClickListener {
             Consent.getConsents { consents ->
                 Log.d("Custom_Identity_Fragment", "Got Consents: $consents")

--- a/code/app/src/main/java/com/adobe/marketing/edge/identity/app/ui/CustomIdentityFragment.kt
+++ b/code/app/src/main/java/com/adobe/marketing/edge/identity/app/ui/CustomIdentityFragment.kt
@@ -40,17 +40,11 @@ class CustomIdentityFragment : Fragment() {
     ): View? {
         val sharedViewModel by activityViewModels<SharedViewModel>()
 
-        // Instantiates a layout XML file (compiled only!) into its corresponding View objects.
-        // In this case, inflating the custom identity fragment (read: component)
         val root = inflater.inflate(R.layout.fragment_custom_identity, container, false)
 
-        // Then find the real views (inflated above) using their resource IDs
         val adIdEditText = root.findViewById<EditText>(R.id.text_ad_id)
-        // Set the text in the textbox equal to the real value stored in local state
         adIdEditText.setText(sharedViewModel.adId.value)
-        // When a text change is detected (after change is completed)
         adIdEditText.doAfterTextChanged {
-            // Each text value store has its own setter
             sharedViewModel.setAdId(it.toString())
         }
 
@@ -107,70 +101,14 @@ class CustomIdentityFragment : Fragment() {
         }
 
         // Button for Set Ad ID behavior
-        // Sets the advertising identifier using the MobileCore API
-        // This only sets the ad ID provided, it does not incorporate the request tracking authorization
-        // flow; that is handled separately
+        // Sets the advertising identifier set in the corresponding textfield using the MobileCore API
         root.findViewById<Button>(R.id.btn_set_ad_id).setOnClickListener {
             val adId: String? = sharedViewModel.adId.value
-
             MobileCore.setAdvertisingIdentifier(adId)
         }
 
-        // In Android, users are automatically opted-in to ad ID tracking
-        // They can choose to opt out of tracking in Android Settings at the device(?) level (not sure if
-        // individual app level permissions are possible)
-        // thus developers using ad ID should get ad ID from the API each time it is used, as permissions can change
-        // - note: users can see their ad ID value in the settings page for Ads
-        // - note: unlike iOS, the permission is more passive, where the user has to seek out the option to turn
-        // off tracking, and no permissions prompt is shown on first launch, etc.
-        //
-
-        // Accessibility of ad ID through AdvertisingIdClient APIs:
-        // All devices that support Google Play Services follow the device level opt-in/out status, regardless of the app’s target SDK level.
-        // This is enforced starting from April 1, 2022.
-        // Prior to this, it was only applied to devices running Android 12.
-
-        // Required manifest permissions to use ad ID (normal level permission):
-        // This is only required for Android 13+ (Apps with target API level set to 33 (Android 13))
-        // Conversely, for apps with target API level set to 32 (Android 12L) or older, this permission is not needed.
-        // If it is not declared when required, you will get an all-zero ad ID.
-        // In the test app's case, the current targetSdkVersion is 30, so the permission is not required.
-        //
-        // The permission is:
-        // <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
-        // To prevent permission merging:
-        // <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove"/>
-        //
-        // note: some SDKs may already include this permission in their manifest; ex: Google Mobile Ads SDK (play-services-ads)
-        // consider merging manifest files: https://developer.android.com/studio/build/manage-manifests#merge-manifests
-
-        // Based on simulator testing:
-        // - the opt-in/out status change or resetting the ad ID value does not affect app lifecycle;
-        // that is, unlike iOS the app is not terminated with value or opt-in/out status changes
-        //     - thus, the guidance for only accessing the ad ID through the API and not caching the value;
-        //     permissions for ad tracking and/or the value of the ID itself may be changed at any time
-        //     - practically, it may be cumbersome to detect changes at arbitrary points in the logic throughout the app;
-        //     it may be helpful to use:
-        //         - a getter helper for ad ID that detects and handles changes in value or opt-in/out
-        //         - using app lifecycle foreground event to check for ad ID value or opt-in/out changes
-        // - opt-out does not seem to cause the admob SDK to return an all-zeros ad ID (based on testing with emulator)
-        //
-
-        // Google Mobile Ads Lite SDK
-        // https://developers.google.com/admob/android/lite-sdk
-        // API reference: https://developers.google.com/android/reference/com/google/android/gms/ads/identifier/AdvertisingIdClient
-        // AdMob requires an application ID (free sample id given by Google for testing purposes) specified in the AndroidManifest.xml
-        // for the app to run, when the SDK is included in the build (otherwise the app will crash).
-        // However, the SDK doesn't have to be initialized in order to use the ad ID fetching flow:
-        // https://developers.google.com/admob/android/quick-start#import_the_mobile_ads_sdk
-
-        // AndroidX Ads SDK
-        // https://developer.android.com/jetpack/androidx/releases/ads#1.0.0-alpha04
-        // API reference: https://developer.android.com/reference/androidx/ads/identifier/AdvertisingIdClient
-        // Doesn't work (also see commented implementation below):
-        // https://stackoverflow.com/questions/59217195/how-do-i-use-or-implement-an-android-advertising-id-provider
-        // Note: the last time the AndroidX SDK was updated was January 22, 2020: Version 1.0.0-alpha04
-
+        // For details on implementation tips and differences between Google Play Services Ads vs AndroidX Ads,
+        // please see the project Documentation -> AEPEdgeIdentity.md : Test App -> GAID Implementation
         root.findViewById<Button>(R.id.btn_get_gaid).setOnClickListener {
             val context = context
             Log.d("Custom_Identity_Fragment", "context: $context, appContext: ${context?.applicationContext}")
@@ -181,37 +119,6 @@ class CustomIdentityFragment : Fragment() {
                 GlobalScope.launch {
                     sharedViewModel.getGAID(context.applicationContext)
                 }
-
-                /* Implementation for AndroidX ads, doesn't seem to work; isAdvertisingIdProviderAvailable never returns true even with valid applicationContext
-                if (AdvertisingIdClient.isAdvertisingIdProviderAvailable(context.applicationContext)) {
-                    val advertisingIdInfoListenableFuture = AdvertisingIdClient.getAdvertisingIdInfo(context.applicationContext)
-                    addCallback(advertisingIdInfoListenableFuture,
-                            object : FutureCallback<AdvertisingIdInfo> {
-                                override fun onSuccess(adInfo: AdvertisingIdInfo?) {
-                                    if (adInfo == null) {
-                                        return
-                                    }
-                                    val id = adInfo.id
-                                    val providerPackageName = adInfo.providerPackageName
-                                    val isLimitTrackingEnabled = adInfo.isLimitAdTrackingEnabled
-                                    Log.d("Custom_Identity_Fragment", "id: $id, providerPackageName: $providerPackageName, isLimitTrackingEnabled: $isLimitTrackingEnabled")
-                                }
-
-                                override fun onFailure(t: Throwable) {
-                                    Log.e("Custom_Identity_Fragment", "Failed to connect to Advertising ID provider: $t")
-                                    // Try to connect to the Advertising ID provider again, or fall
-                                    // back to an ads solution that doesn't require using the
-                                    // Advertising ID library.
-                                }
-                            },
-                            Executors.newSingleThreadExecutor()
-                    )
-                } else {
-                    Log.d("Custom_Identity_Fragment", "The Advertising ID client library is unavailable.")
-                    // The Advertising ID client library is unavailable. Use a different
-                    // library to perform any required ads use cases.
-                }
-                 */
             }
         }
 

--- a/code/app/src/main/java/com/adobe/marketing/edge/identity/app/ui/CustomIdentityFragment.kt
+++ b/code/app/src/main/java/com/adobe/marketing/edge/identity/app/ui/CustomIdentityFragment.kt
@@ -32,8 +32,12 @@ import com.adobe.marketing.mobile.edge.identity.AuthenticatedState
 import com.adobe.marketing.mobile.edge.identity.Identity
 import com.adobe.marketing.mobile.edge.identity.IdentityItem
 import com.adobe.marketing.mobile.edge.identity.IdentityMap
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+
+private const val LOG_TAG = "Custom_Identity_Fragment"
+private const val ZERO_ADVERTISING_ID = "00000000-0000-0000-0000-000000000000"
 
 class CustomIdentityFragment : Fragment() {
 
@@ -42,7 +46,6 @@ class CustomIdentityFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        val LOG_TAG = "Custom_Identity_Fragment"
         val sharedViewModel by activityViewModels<SharedViewModel>()
 
         val root = inflater.inflate(R.layout.fragment_custom_identity, container, false)
@@ -113,16 +116,16 @@ class CustomIdentityFragment : Fragment() {
         }
 
         // For details on implementation tips and differences between Google Play Services Ads vs AndroidX Ads,
-        // please see the project Documentation -> AEPEdgeIdentity.md : Test App -> GAID Implementation
+        // please see the project Documentation -> AEPEdgeIdentity.md : Android Test App -> Testing tips with Android advertising identifier
         root.findViewById<Button>(R.id.btn_get_gaid).setOnClickListener {
             val context = context
             Log.d(LOG_TAG, "context: $context, appContext: ${context?.applicationContext}")
             if (context != null) {
-                // Implementation for google play services ads
-                // Logic implemented in ViewModel to leverage managed Kotlin coroutine scope from lifecycle-viewmodel-ktx
-                // lifecycle-viewmodel-ktx requires compiled sdk version 31+
-                GlobalScope.launch {
-                    sharedViewModel.getGAID(context.applicationContext)
+                // Create IO (background) coroutine scope to fetch ad ID value
+                val scope = CoroutineScope(Dispatchers.IO).launch {
+                    val adID = sharedViewModel.getGAID(context.applicationContext)
+                    Log.d(LOG_TAG, "Sending ad ID value: $adID to MobileCore.setAdvertisingIdentifier")
+                    MobileCore.setAdvertisingIdentifier(adID)
                 }
             }
         }
@@ -133,8 +136,8 @@ class CustomIdentityFragment : Fragment() {
         }
 
         root.findViewById<Button>(R.id.btn_set_ad_id_all_zeros).setOnClickListener {
-            Log.d(LOG_TAG, "Setting advertising identifier to: 00000000-0000-0000-0000-000000000000")
-            MobileCore.setAdvertisingIdentifier("00000000-0000-0000-0000-000000000000")
+            Log.d(LOG_TAG, "Setting advertising identifier to: $ZERO_ADVERTISING_ID")
+            MobileCore.setAdvertisingIdentifier(ZERO_ADVERTISING_ID)
         }
 
         root.findViewById<Button>(R.id.btn_get_consents).setOnClickListener {

--- a/code/app/src/main/java/com/adobe/marketing/edge/identity/app/ui/CustomIdentityFragment.kt
+++ b/code/app/src/main/java/com/adobe/marketing/edge/identity/app/ui/CustomIdentityFragment.kt
@@ -12,7 +12,6 @@
 package com.adobe.marketing.edge.identity.app.ui
 
 import android.os.Bundle
-import android.provider.Settings
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
@@ -22,8 +21,6 @@ import android.widget.CheckBox
 import android.widget.EditText
 import android.widget.RadioButton
 import android.widget.RadioGroup
-//import androidx.ads.identifier.AdvertisingIdClient
-//import androidx.ads.identifier.AdvertisingIdInfo
 import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
@@ -34,15 +31,8 @@ import com.adobe.marketing.mobile.edge.identity.AuthenticatedState
 import com.adobe.marketing.mobile.edge.identity.Identity
 import com.adobe.marketing.mobile.edge.identity.IdentityItem
 import com.adobe.marketing.mobile.edge.identity.IdentityMap
-import com.google.android.gms.ads.identifier.AdvertisingIdClient
-
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executor
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
 
 class CustomIdentityFragment : Fragment() {
 
@@ -226,9 +216,7 @@ class CustomIdentityFragment : Fragment() {
                 }
                  */
             }
-
         }
-
 
         return root
     }

--- a/code/app/src/main/java/com/adobe/marketing/edge/identity/app/ui/CustomIdentityFragment.kt
+++ b/code/app/src/main/java/com/adobe/marketing/edge/identity/app/ui/CustomIdentityFragment.kt
@@ -12,6 +12,8 @@
 package com.adobe.marketing.edge.identity.app.ui
 
 import android.os.Bundle
+import android.provider.Settings
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -20,15 +22,28 @@ import android.widget.CheckBox
 import android.widget.EditText
 import android.widget.RadioButton
 import android.widget.RadioGroup
+//import androidx.ads.identifier.AdvertisingIdClient
+//import androidx.ads.identifier.AdvertisingIdInfo
 import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import com.adobe.marketing.edge.identity.app.R
 import com.adobe.marketing.edge.identity.app.model.SharedViewModel
+import com.adobe.marketing.mobile.MobileCore
 import com.adobe.marketing.mobile.edge.identity.AuthenticatedState
 import com.adobe.marketing.mobile.edge.identity.Identity
 import com.adobe.marketing.mobile.edge.identity.IdentityItem
 import com.adobe.marketing.mobile.edge.identity.IdentityMap
+import com.google.android.gms.ads.identifier.AdvertisingIdClient
+import com.google.common.util.concurrent.FutureCallback
+import com.google.common.util.concurrent.Futures.addCallback
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 class CustomIdentityFragment : Fragment() {
 
@@ -39,7 +54,19 @@ class CustomIdentityFragment : Fragment() {
     ): View? {
         val sharedViewModel by activityViewModels<SharedViewModel>()
 
+        // Instantiates a layout XML file (compiled only!) into its corresponding View objects.
+        // In this case, inflating the custom identity fragment (read: component)
         val root = inflater.inflate(R.layout.fragment_custom_identity, container, false)
+
+        // Then find the real views (inflated above) using their resource IDs
+        val adIdEditText = root.findViewById<EditText>(R.id.text_ad_id)
+        // Set the text in the textbox equal to the real value stored in local state
+        adIdEditText.setText(sharedViewModel.adId.value)
+        // When a text change is detected (after change is completed)
+        adIdEditText.doAfterTextChanged {
+            // Each text value store has its own setter
+            sharedViewModel.setAdId(it.toString())
+        }
 
         val identifierEditText = root.findViewById<EditText>(R.id.text_identifier)
         identifierEditText.setText(sharedViewModel.identifier.value)
@@ -92,6 +119,117 @@ class CustomIdentityFragment : Fragment() {
             val item = IdentityItem(identifier, authenticatedState, isPrimary)
             Identity.removeIdentity(item, namespace)
         }
+
+        // Button for Set Ad ID behavior
+        // Sets the advertising identifier using the MobileCore API
+        // This only sets the ad ID provided, it does not incorporate the request tracking authorization
+        // flow; that is handled separately
+        root.findViewById<Button>(R.id.btn_set_ad_id).setOnClickListener {
+            val adId: String? = sharedViewModel.adId.value
+
+            MobileCore.setAdvertisingIdentifier(adId)
+        }
+
+        // In Android, users are automatically opted-in to ad ID tracking
+        // They can choose to opt out of tracking in Android Settings at the device(?) level (not sure if
+        // individual app level permissions are possible)
+        // thus developers using ad ID should get ad ID from the API each time it is used, as permissions can change
+        // - note: users can see their ad ID value in the settings page for Ads
+        // - note: unlike iOS, the permission is more passive, where the user has to seek out the option to turn
+        // off tracking, and no permissions prompt is shown on first launch, etc.
+        //
+
+        // Accessibility of ad ID through AdvertisingIdClient APIs:
+        // All devices that support Google Play Services follow the device level opt-in/out status, regardless of the app’s target SDK level.
+        // This is enforced starting from April 1, 2022.
+        // Prior to this, it was only applied to devices running Android 12.
+
+        // Required manifest permissions to use ad ID (normal level permission):
+        // This is only required for Android 13+ (Apps with target API level set to 33 (Android 13))
+        // Conversely, for apps with target API level set to 32 (Android 12L) or older, this permission is not needed.
+        // If it is not declared when required, you will get an all-zero ad ID.
+        // In the test app's case, the current targetSdkVersion is 30, so the permission is not required.
+        //
+        // The permission is:
+        // <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
+        // To prevent permission merging:
+        // <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove"/>
+        //
+        // note: some SDKs may already include this permission in their manifest; ex: Google Mobile Ads SDK (play-services-ads)
+        // consider merging manifest files: https://developer.android.com/studio/build/manage-manifests#merge-manifests
+
+        // Based on simulator testing:
+        // - the opt-in/out status change or resetting the ad ID value does not affect app lifecycle;
+        // that is, unlike iOS the app is not terminated with value or opt-in/out status changes
+        //     - thus, the guidance for only accessing the ad ID through the API and not caching the value;
+        //     permissions for ad tracking and/or the value of the ID itself may be changed at any time
+        //     - practically, it may be cumbersome to detect changes at arbitrary points in the logic throughout the app;
+        //     it may be helpful to use:
+        //         - a getter helper for ad ID that detects and handles changes in value or opt-in/out
+        //         - using app lifecycle foreground event to check for ad ID value or opt-in/out changes
+        // - opt-out does not seem to cause the admob SDK to return an all-zeros ad ID (based on testing with emulator)
+        //
+
+        // Google Mobile Ads Lite SDK
+        // https://developers.google.com/admob/android/lite-sdk
+        // API reference: https://developers.google.com/android/reference/com/google/android/gms/ads/identifier/AdvertisingIdClient
+        // AdMob requires an application ID (free sample id given by Google for testing purposes) specified in the AndroidManifest.xml
+        // for the app to run, when the SDK is included in the build (otherwise the app will crash).
+        // However, the SDK doesn't have to be initialized in order to use the ad ID fetching flow:
+        // https://developers.google.com/admob/android/quick-start#import_the_mobile_ads_sdk
+
+        // AndroidX Ads SDK
+        // https://developer.android.com/jetpack/androidx/releases/ads#1.0.0-alpha04
+        // API reference: https://developer.android.com/reference/androidx/ads/identifier/AdvertisingIdClient
+        // Doesn't work (also see commented implementation below):
+        // https://stackoverflow.com/questions/59217195/how-do-i-use-or-implement-an-android-advertising-id-provider
+        // Note: the last time the AndroidX SDK was updated was January 22, 2020: Version 1.0.0-alpha04
+
+        root.findViewById<Button>(R.id.btn_get_gaid).setOnClickListener {
+            val context = context
+            Log.d("Custom_Identity_Fragment", "context: $context, appContext: ${context?.applicationContext}")
+            if (context != null) {
+                // Implementation for google play services ads
+                // Logic implemented in ViewModel to leverage managed Kotlin coroutine scope from lifecycle-viewmodel-ktx
+                // lifecycle-viewmodel-ktx requires compiled sdk version 31+
+                GlobalScope.launch {
+                    sharedViewModel.getGAID(context.applicationContext)
+                }
+
+                /* Implementation for AndroidX ads, doesn't seem to work; isAdvertisingIdProviderAvailable never returns true even with valid applicationContext
+                if (AdvertisingIdClient.isAdvertisingIdProviderAvailable(context.applicationContext)) {
+                    val advertisingIdInfoListenableFuture = AdvertisingIdClient.getAdvertisingIdInfo(context.applicationContext)
+                    addCallback(advertisingIdInfoListenableFuture,
+                            object : FutureCallback<AdvertisingIdInfo> {
+                                override fun onSuccess(adInfo: AdvertisingIdInfo?) {
+                                    if (adInfo == null) {
+                                        return
+                                    }
+                                    val id = adInfo.id
+                                    val providerPackageName = adInfo.providerPackageName
+                                    val isLimitTrackingEnabled = adInfo.isLimitAdTrackingEnabled
+                                    Log.d("Custom_Identity_Fragment", "id: $id, providerPackageName: $providerPackageName, isLimitTrackingEnabled: $isLimitTrackingEnabled")
+                                }
+
+                                override fun onFailure(t: Throwable) {
+                                    Log.e("Custom_Identity_Fragment", "Failed to connect to Advertising ID provider: $t")
+                                    // Try to connect to the Advertising ID provider again, or fall
+                                    // back to an ads solution that doesn't require using the
+                                    // Advertising ID library.
+                                }
+                            },
+                            Executors.newSingleThreadExecutor()
+                    )
+                } else {
+                    Log.d("Custom_Identity_Fragment", "The Advertising ID client library is unavailable.")
+                    // The Advertising ID client library is unavailable. Use a different
+                    // library to perform any required ads use cases.
+                }
+                 */
+            }
+
+        }
+
 
         return root
     }

--- a/code/app/src/main/res/layout/fragment_custom_identity.xml
+++ b/code/app/src/main/res/layout/fragment_custom_identity.xml
@@ -10,31 +10,28 @@
         android:id="@+id/layout_identifier"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
         android:layout_margin="8dp"
         android:layout_marginTop="20dp"
+        android:orientation="horizontal"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        >
+        app:layout_constraintTop_toTopOf="parent">
 
         <TextView
             android:id="@+id/label_identifier"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="start|center_vertical"
-            android:textSize="18sp"
             android:text="@string/label_identifier"
-            />
-        
+            android:textSize="18sp" />
+
         <EditText
             android:id="@+id/text_identifier"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
             android:layout_gravity="end|center_vertical"
-            android:singleLine="true"
-            />
+            android:layout_weight="1"
+            android:singleLine="true" />
 
     </LinearLayout>
 
@@ -42,29 +39,26 @@
         android:id="@+id/layout_namespace"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
         android:layout_margin="8dp"
-        app:layout_constraintTop_toBottomOf="@id/layout_identifier"
+        android:orientation="horizontal"
         app:layout_constraintHorizontal_bias="0.52"
-        >
+        app:layout_constraintTop_toBottomOf="@id/layout_identifier">
 
         <TextView
             android:id="@+id/label_namespace"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="start|center_vertical"
-            android:textSize="18sp"
             android:text="@string/label_namespace"
-            />
+            android:textSize="18sp" />
 
         <EditText
             android:id="@+id/text_namespace"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
             android:layout_gravity="end|center_vertical"
-            android:singleLine="true"
-            />
+            android:layout_weight="1"
+            android:singleLine="true" />
 
     </LinearLayout>
 
@@ -72,18 +66,16 @@
         android:id="@+id/layout_primary"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
         android:layout_margin="8dp"
-        app:layout_constraintTop_toBottomOf="@id/layout_namespace"
+        android:orientation="horizontal"
         app:layout_constraintHorizontal_bias="0.52"
-        >
+        app:layout_constraintTop_toBottomOf="@id/layout_namespace">
 
         <CheckBox
             android:id="@+id/checkbox_is_primary"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/checkbox_is_primary"
-            />
+            android:text="@string/checkbox_is_primary" />
 
     </LinearLayout>
 
@@ -91,65 +83,109 @@
         android:id="@+id/layout_authenticated"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
         android:layout_margin="8dp"
-        app:layout_constraintTop_toBottomOf="@id/layout_primary"
+        android:orientation="horizontal"
         app:layout_constraintHorizontal_bias="0.52"
-        >
+        app:layout_constraintTop_toBottomOf="@id/layout_primary">
 
         <RadioGroup
             android:id="@+id/radio_group_authenticated"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            >
-            <RadioButton android:id="@+id/radio_ambiguous"
+            android:orientation="horizontal">
+
+            <RadioButton
+                android:id="@+id/radio_ambiguous"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/authentication_ambiguous"
                 android:layout_weight="1"
                 android:checked="true"
-                />
-            <RadioButton android:id="@+id/radio_authenticated"
+                android:text="@string/authentication_ambiguous" />
+
+            <RadioButton
+                android:id="@+id/radio_authenticated"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/authentication_authenticated"
                 android:layout_weight="1"
-                />
-            <RadioButton android:id="@+id/radio_logged_out"
+                android:text="@string/authentication_authenticated" />
+
+            <RadioButton
+                android:id="@+id/radio_logged_out"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/authentication_logged_out"
                 android:layout_weight="1"
-                />
+                android:text="@string/authentication_logged_out" />
         </RadioGroup>
 
     </LinearLayout>
 
     <LinearLayout
+        android:id="@+id/linearLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
         android:layout_margin="8dp"
+        android:orientation="horizontal"
         app:layout_constraintTop_toBottomOf="@id/layout_authenticated"
-        app:layout_constraintHorizontal_bias="0.52"
-        >
+        tools:layout_editor_absoluteX="8dp">
 
         <Button
             android:id="@+id/btn_update_identities"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/btn_update_identities"
             android:layout_weight="1"
-            />
+            android:text="@string/btn_update_identities" />
 
         <Button
             android:id="@+id/btn_remove_identities"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/btn_remove_identities"
             android:layout_weight="1"
-            />
+            android:text="@string/btn_remove_identities" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/layout_request_authorization"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/linearLayout">
+
+        <Button
+            android:id="@+id/btn_get_gaid"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/btn_get_gaid" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/layout_set_ad_id"
+        android:layout_width="402dp"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/layout_request_authorization">
+
+        <Button
+            android:id="@+id/btn_set_ad_id"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/btn_set_ad_id" />
+
+        <EditText
+            android:id="@+id/text_ad_id"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:ems="10"
+            android:hint="@string/label_enter_ad_id" />
 
     </LinearLayout>
 

--- a/code/app/src/main/res/layout/fragment_custom_identity.xml
+++ b/code/app/src/main/res/layout/fragment_custom_identity.xml
@@ -148,6 +148,7 @@
         android:id="@+id/layout_request_authorization"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_margin="8dp"
         android:orientation="horizontal"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"
@@ -164,8 +165,9 @@
 
     <LinearLayout
         android:id="@+id/layout_set_ad_id"
-        android:layout_width="402dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_margin="8dp"
         android:orientation="horizontal"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"
@@ -190,6 +192,30 @@
     </LinearLayout>
 
     <LinearLayout
+        android:id="@+id/layout_set_ad_id_values"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="8dp"
+        android:orientation="horizontal"
+        app:layout_constraintTop_toBottomOf="@id/layout_set_ad_id"
+        tools:layout_editor_absoluteX="1dp">
+
+        <Button
+            android:id="@+id/btn_set_ad_id_null"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/btn_set_ad_id_null" />
+
+        <Button
+            android:id="@+id/btn_set_ad_id_all_zeros"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/btn_set_ad_id_all_zeros" />
+    </LinearLayout>
+
+    <LinearLayout
         android:id="@+id/layout_consents"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -198,7 +224,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/layout_set_ad_id">
+        app:layout_constraintTop_toBottomOf="@id/layout_set_ad_id_values">
 
         <Button
             android:id="@+id/btn_get_consents"

--- a/code/app/src/main/res/layout/fragment_custom_identity.xml
+++ b/code/app/src/main/res/layout/fragment_custom_identity.xml
@@ -189,4 +189,23 @@
 
     </LinearLayout>
 
+    <LinearLayout
+        android:id="@+id/layout_consents"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="8dp"
+        android:orientation="horizontal"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/layout_set_ad_id">
+
+        <Button
+            android:id="@+id/btn_get_consents"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/btn_get_consents" />
+    </LinearLayout>
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/code/app/src/main/res/values/secrets.xml
+++ b/code/app/src/main/res/values/secrets.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- See Google's reference on how to get your AdMob app ID: https://developers.google.com/admob/android/quick-start -->
+    <!-- Free public test app ID from Google (see step 3): https://developers.google.com/admob/android/quick-start#import_the_mobile_ads_sdk -->
+    <string name="gms_ads_app_id">ENTER_YOUR_ADS_APP_ID_HERE</string>
+</resources>

--- a/code/app/src/main/res/values/strings.xml
+++ b/code/app/src/main/res/values/strings.xml
@@ -37,9 +37,12 @@
 
     <!-- Custom Identity Fragment -->
     <!-- Buttons -->
+    <string name="btn_get_consents">Get Current Consents</string>
     <string name="btn_get_gaid">Update Ad ID With Current GAID</string>
     <string name="btn_set_ad_id">Set Ad ID</string>
-    <string name="btn_get_consents">Get Current Consents</string>
+    <string name="btn_set_ad_id_all_zeros">Set Ad ID as all-zeros</string>
+    <string name="btn_set_ad_id_null">Set Ad ID as null</string>
+
     <!-- Labels -->
     <string name="label_enter_ad_id">Enter Ad ID</string>
 </resources>

--- a/code/app/src/main/res/values/strings.xml
+++ b/code/app/src/main/res/values/strings.xml
@@ -37,8 +37,9 @@
 
     <!-- Custom Identity Fragment -->
     <!-- Buttons -->
-    <string name="btn_set_ad_id">Set Ad ID</string>
     <string name="btn_get_gaid">Update Ad ID With Current GAID</string>
+    <string name="btn_set_ad_id">Set Ad ID</string>
+    <string name="btn_get_consents">Get Current Consents</string>
     <!-- Labels -->
     <string name="label_enter_ad_id">Enter Ad ID</string>
 </resources>

--- a/code/app/src/main/res/values/strings.xml
+++ b/code/app/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="nav_header_desc">Navigation header</string>
     <string name="action_settings">Settings</string>
 
+
     <string name="menu_get_identity">View Identities</string>
     <string name="menu_custom_identity">Set Custom Identity</string>
     <string name="menu_multiple_identity">Test Multiple Identities</string>
@@ -33,4 +34,11 @@
     <string name="label_session_url">Copy Assurance Session URL to here</string>
     <string name="btn_connect">Connect</string>
     <string name="menu_assurance">Assurance</string>
+
+    <!-- Custom Identity Fragment -->
+    <!-- Buttons -->
+    <string name="btn_set_ad_id">Set Ad ID</string>
+    <string name="btn_get_gaid">Update Ad ID With Current GAID</string>
+    <!-- Labels -->
+    <string name="label_enter_ad_id">Enter Ad ID</string>
 </resources>

--- a/code/build.gradle
+++ b/code/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        kotlin_version = '1.3.72'
+        kotlin_version = '1.5.0'
     }
     repositories {
         google()
@@ -10,7 +10,7 @@ buildscript {
         maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.0.1"
+        classpath 'com.android.tools.build:gradle:7.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.diffplug.spotless:spotless-plugin-gradle:5.12.5"
         // NOTE: Do not place your application dependencies here; they belong

--- a/code/build.gradle
+++ b/code/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.2'
+        classpath 'com.android.tools.build:gradle:4.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.diffplug.spotless:spotless-plugin-gradle:5.12.5"
         // NOTE: Do not place your application dependencies here; they belong

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -1,11 +1,6 @@
 # Project-wide Gradle settings.
 
-org.gradle.jvmargs=-Xmx2048m \
-  --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+org.gradle.jvmargs=-Xmx2048m
 
 android.useAndroidX=true
 android.enableJetifier=true

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -1,6 +1,11 @@
 # Project-wide Gradle settings.
 
-org.gradle.jvmargs=-Xmx2048m
+org.gradle.jvmargs=-Xmx2048m \
+  --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 
 android.useAndroidX=true
 android.enableJetifier=true

--- a/code/gradle/wrapper/gradle-wrapper.properties
+++ b/code/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Mar 18 11:50:52 PDT 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/code/gradle/wrapper/gradle-wrapper.properties
+++ b/code/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jan 25 11:55:49 PST 2021
+#Fri Mar 18 11:50:52 PDT 2022
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Update for the test app to be able to: 
- Fetch the ad ID from device (GAID) using the [Google Mobile Ads Lite SDK ](https://developers.google.com/admob/android/lite-sdk)
- Update advertising identifier using the Edge Identity extension (through MobileCore API)

The new functionality has been added under the Set Custom Identity view. The button language for fetching the GAID is not the same as the iOS test app, because the flow for ad ID permissions in Android is slightly different; Android automatically opts-in all users to ad ID tracking instead of a default opt-out status and asking permissions with a prompt like in iOS. 

Updates to build.gradle (:app):
- Kotlin version 1.3.72 -> 1.5.0 to enable using lifecycle-viewmodel-ktx
- play-services-ads-lite:20.6.0 to use Android ad ID provider APIs
- kotlinx-coroutines-android:1.6.0 to use Kotlin coroutines to handle async call to get ad ID
- lifecycle-viewmodel-ktx:2.5.0-alpha06 to handle managing coroutine scope lifecycle within ViewModel
- multidex:2.0.1 to fix exceeding 64k reference limit issue

## Related Issue

Please see Jira task: [AMSDK-11332 - (Android) Update Edge Identity test app for adid consent testing](https://jira.corp.adobe.com/browse/AMSDK-11332)


## Motivation and Context

With the new advertising identifier capabilities added to Edge Identity, the test app requires updates to be able to effectively test the new features using the Android Emulator.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested this implementation using the Android Emulator Pixel_3a_API_32_arm64-v8a, from a fresh install with a valid `LAUNCH_ENVIRONMENT_ID`. Navigated using hamburger menu to Set Custom Identity view, using the various new ad ID related buttons to test that the correct advertising identifier and consent events were being dispatched. Also verified the same in the View Identities view. Tested with the device level ad ID settings toggled on and off to verify correct all-zeros ad ID fetched when ad ID tracking disabled, and vice versa.

## Screenshots (if appropriate):
Note the new buttons for ad ID related functionality:
- Update Ad ID with Current GAID
Note: all Set Ad ID buttons use the `MobileCore.setAdvertisingIdentifier()` API, with special cases handled by dedicated button for ease of testing.
- Set Ad ID + textfield
- Set Ad ID as null
- Set Ad ID as all-zeros 
- Get Current Consents - uses `Consent.getConsents` API and prints log of result to console
Updated Set Custom Identity view:
![Screen Shot 2022-04-26 at 1 56 32 PM](https://user-images.githubusercontent.com/95260439/165390957-dfece243-9501-4a61-a03a-7b9b96348c75.png)

![Screen Shot 2022-04-26 at 2 01 33 PM](https://user-images.githubusercontent.com/95260439/165391748-273bd442-cb0f-4b23-9efe-10645a04c6cf.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. (see related documentation PR https://github.com/adobe/aepsdk-edgeidentity-android/pull/58)
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
