### PR TITLE
Upgrade AGP, Gradle, language dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,20 @@ ci/
 
 # Secrets
 **/*/values/secrets.xml
+
+# Local configuration file (sdk path, etc)
+local.properties
+
+# Android Studio Navigation editor temp files
+.navigation/
+
+# Coverage tools
+jacoco.exec
+
+# Application files
+*.apk
+*.aar
+*.aab
+
+# Dex files for ART/Dalvik VM
+*.dex

--- a/code/app/build.gradle
+++ b/code/app/build.gradle
@@ -13,6 +13,8 @@ spotless {
 }
 
 android {
+    namespace 'com.adobe.marketing.edge.identity.app'
+
     compileSdkVersion rootProject.ext.compileSdkVersion
 
     defaultConfig {

--- a/code/app/build.gradle
+++ b/code/app/build.gradle
@@ -15,14 +15,14 @@ spotless {
 android {
     namespace 'com.adobe.marketing.edge.identity.app'
 
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdk rootProject.ext.compileSdkVersion
 
     defaultConfig {
         applicationId "com.adobe.marketing.edge.identity.app"
-        minSdkVersion rootProject.ext.minSdkVersion
-        targetSdkVersion rootProject.ext.targetSdkVersion
+        minSdk rootProject.ext.minSdkVersion
+        targetSdk rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
-        versionName project.property('moduleVersion') as String ?: "1.0"
+        versionName project.property('moduleVersion') as String ?: "1.0.0 (Default)"
         multiDexEnabled = true
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -45,7 +45,6 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.kotlinVersion}"
     implementation 'androidx.core:core-ktx:1.3.2'
     implementation 'androidx.appcompat:appcompat:1.2.0'

--- a/code/app/build.gradle
+++ b/code/app/build.gradle
@@ -1,7 +1,8 @@
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
-apply plugin: "com.diffplug.spotless"
+plugins {
+    id 'com.android.application'
+    id 'com.diffplug.spotless'
+    id 'org.jetbrains.kotlin.android'
+}
 
 spotless {
     kotlin {
@@ -12,14 +13,14 @@ spotless {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion rootProject.ext.compileSdkVersion
 
     defaultConfig {
         applicationId "com.adobe.marketing.edge.identity.app"
-        minSdkVersion 19
-        targetSdkVersion 31
-        versionCode 1
-        versionName "1.0"
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        versionCode rootProject.ext.versionCode
+        versionName project.property('moduleVersion') as String ?: "1.0"
         multiDexEnabled = true
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -35,14 +36,15 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = rootProject.ext.kotlinJvmTarget
     }
 }
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.kotlinVersion}"
     implementation 'androidx.core:core-ktx:1.3.2'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'

--- a/code/app/src/main/AndroidManifest.xml
+++ b/code/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.adobe.marketing.edge.identity.app">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/code/build.gradle
+++ b/code/build.gradle
@@ -27,9 +27,6 @@ ext {
     mockitoCoreVersion = "2.28.2"
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
-    // build tools
-    buildToolsVersion = "29.0.3"
-
     // spotless
     prettierVersion = "2.7.1"
     prettierPluginJavaVersion = "1.6.2"

--- a/code/build.gradle
+++ b/code/build.gradle
@@ -1,53 +1,43 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    ext {
-        kotlin_version = '1.5.0'
-    }
-    repositories {
-        google()
-        mavenCentral()
-        maven { url "https://plugins.gradle.org/m2/" }
-        maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "com.diffplug.spotless:spotless-plugin-gradle:5.12.5"
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
-    }
-}
 
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-        maven { url "https://plugins.gradle.org/m2/" }
-        maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
-    }
-
-    apply plugin: 'maven-publish'
-}
-
-task clean(type: Delete) {
-    delete rootProject.buildDir
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'com.diffplug.gradle.spotless' version '6.11.0' apply false
+    id 'org.jetbrains.kotlin.android' version "1.6.21" apply false
 }
 
 ext {
     // android config
     minSdkVersion = 19
-    targetSdkVersion = 29
-    compileSdkVersion = 29
+    targetSdkVersion = 33
+    compileSdkVersion = 33
     versionCode = 1
 
     // java config
-    sourceCompatibility = JavaVersion.VERSION_1_7
-    targetCompatibility = JavaVersion.VERSION_1_7
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 
-    // dependencies
+    // kotlin config
+    kotlinVersion = "1.6.21"
+    kotlinJvmTarget = "1.8"
+
+    // test dependencies
     junitVersion = "1.1.2"
     mockitoCoreVersion = "2.28.2"
-    buildToolsVersion = "29.0.3"
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    jacocoVersion = "0.8.5"
+
+    // build tools
+    buildToolsVersion = "29.0.3"
+
+    // spotless
+    prettierVersion = "2.7.1"
+    prettierPluginJavaVersion = "1.6.2"
+
+    // jacoco
+    jacocoVersion = "0.8.8"
+}
+
+task clean(type: Delete) {
+    delete rootProject.buildDir
 }

--- a/code/build.gradle
+++ b/code/build.gradle
@@ -1,8 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 plugins {
-    id 'com.android.application' version '7.3.1' apply false
-    id 'com.android.library' version '7.3.1' apply false
+    id 'com.android.application' version '7.3.0' apply false
+    id 'com.android.library' version '7.3.0' apply false
     id 'com.diffplug.gradle.spotless' version '6.11.0' apply false
     id 'org.jetbrains.kotlin.android' version "1.6.21" apply false
 }
@@ -23,7 +23,7 @@ ext {
     kotlinJvmTarget = "1.8"
 
     // test dependencies
-    junitVersion = "1.1.2"
+    junitVersion = "1.1.3"
     mockitoCoreVersion = "2.28.2"
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/code/edgeidentity/build.gradle
+++ b/code/edgeidentity/build.gradle
@@ -17,7 +17,7 @@ spotless {
         toggleOffOn("format:off", "format:on")
         target "src/*/java/**/*.java"
         removeUnusedImports()
-        prettier(['prettier': '2.3.0', 'prettier-plugin-java': '1.1.0'])
+        prettier(['prettier': rootProject.ext.prettierVersion, 'prettier-plugin-java': rootProject.ext.prettierPluginJavaVersion])
                 .config(['parser': 'java', 'tabWidth': 4, 'useTabs': true, 'printWidth': 120])
         endWithNewline()
         licenseHeaderFile "../../config/formatter/adobe.header.txt"
@@ -48,12 +48,6 @@ android {
         debug {
             testCoverageEnabled true
             debuggable true
-
-            // Functional tests will fail without this flag as this module exceeds the DEX limit.
-            // It is sufficient to enable this for debug as it is the type used for functional tests.
-            // Consuming apps are responsible for making changes to their gradle to overcome
-            // the DEX limit as necessary.
-            multiDexEnabled true
         }
 
         release {
@@ -134,7 +128,7 @@ publishing {
             pom {
                 name = mavenRepoName
                 description = mavenRepoDescription
-                url = 'https://aep-sdks.gitbook.io'
+                url = 'https://developer.adobe.com/client-sdks'
                 licenses {
                     license {
                         name = 'Adobe Proprietary'
@@ -148,9 +142,9 @@ publishing {
                     }
                 }
                 scm {
-                    connection = 'scm:git:github.com//Adobe-Marketing-Cloud/acp-sdks.git'
-                    developerConnection = 'scm:git:ssh://github.com//Adobe-Marketing-Cloud/acp-sdks.git'
-                    url = 'https://github.com/Adobe-Marketing-Cloud/acp-sdks'
+                    connection = 'scm:git:github.com//adobe/aepsdk-edgeidentity-android.git'
+                    developerConnection = 'scm:git:ssh://github.com//adobe/aepsdk-edgeidentity-android.git'
+                    url = 'https://github.com/adobe/aepsdk-edgeidentity-android'
                 }
                 withXml {
                     def dependenciesNode = asNode().appendNode('dependencies')
@@ -224,7 +218,6 @@ task platformFunctionalTestJacocoReport(type: JacocoReport, dependsOn: "createPh
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.2.0'
 
     // Adobe Mobile SDK Core
     implementation "com.adobe.marketing.mobile:core:${rootProject.mavenCoreVersion}"
@@ -236,7 +229,6 @@ dependencies {
     testImplementation 'org.powermock:powermock-module-junit4:2.0.0'
     testImplementation 'org.json:json:20180813'
 
-    androidTestImplementation "androidx.test:core:1.4.0"
     androidTestImplementation "androidx.test.ext:junit:${rootProject.ext.junitVersion}"
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     // Using older version of PowerMock as it supports minimum Android API < 26

--- a/code/edgeidentity/build.gradle
+++ b/code/edgeidentity/build.gradle
@@ -76,16 +76,16 @@ android {
     }
 }
 
-android.libraryVariants.all { variant ->
+afterEvaluate {
     tasks.withType(Javadoc) {
-        source = [android.sourceSets.main.java.sourceFiles, android.sourceSets.phone.java.sourceFiles]
-        ext.androidJar = "${android.sdkDirectory}/platforms/${android.compileSdkVersion}/android.jar"
+        source = android.sourceSets.main.java.srcDirs
+        classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+        classpath += files(android.libraryVariants.collect { variant ->
+            variant.javaCompileProvider.get().classpath.files
+        })
 
-        doFirst{classpath = files(variant.javaCompile.classpath.files) + files(ext.androidJar)}
-
-        exclude "**/BuildConfig.java"
-        exclude "**/R.java"
         options {
+            source = "8"
             links "https://developer.android.com/reference"
         }
     }

--- a/code/edgeidentity/build.gradle
+++ b/code/edgeidentity/build.gradle
@@ -25,7 +25,9 @@ spotless {
 }
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    namespace 'com.adobe.marketing.mobile.edge.identity'
+
+    compileSdk rootProject.ext.compileSdkVersion
 
     defaultConfig {
         minSdk rootProject.ext.minSdkVersion
@@ -183,7 +185,7 @@ signing {
 }
 
 task platformUnitTestJacocoReport(type: JacocoReport, dependsOn: "testPhoneDebugUnitTest") {
-    def excludeRegex = ['**/ADB*.class', '**/BuildConfig.class']
+    def excludeRegex = ['**/BuildConfig.class']
     def debugTree = fileTree(dir: "${project.buildDir}/intermediates/javac/phoneDebug/classes/com/adobe/marketing/mobile", excludes: excludeRegex)
 
     additionalClassDirs.setFrom files([debugTree])

--- a/code/edgeidentity/build.gradle
+++ b/code/edgeidentity/build.gradle
@@ -35,7 +35,6 @@ android {
 
         testInstrumentationRunner rootProject.ext.testInstrumentationRunner
         consumerProguardFiles "consumer-rules.pro"
-        multiDexEnabled true
     }
 
     flavorDimensions "target"
@@ -49,6 +48,12 @@ android {
         debug {
             testCoverageEnabled true
             debuggable true
+
+            // Functional tests will fail without this flag as this module exceeds the DEX limit.
+            // It is sufficient to enable this for debug as it is the type used for functional tests.
+            // Consuming apps are responsible for making changes to their gradle to overcome
+            // the DEX limit as necessary.
+            multiDexEnabled true
         }
 
         release {

--- a/code/edgeidentity/build.gradle
+++ b/code/edgeidentity/build.gradle
@@ -1,8 +1,10 @@
-apply plugin: 'com.android.library'
-apply plugin: 'jacoco'
-apply plugin: 'maven-publish'
-apply plugin: 'signing'
-apply plugin: "com.diffplug.spotless"
+plugins {
+    id 'com.android.library'
+    id 'jacoco'
+    id 'maven-publish'
+    id 'signing'
+    id 'com.diffplug.spotless'
+}
 
 jacoco {
     toolVersion = rootProject.ext.jacocoVersion
@@ -31,6 +33,7 @@ android {
 
         testInstrumentationRunner rootProject.ext.testInstrumentationRunner
         consumerProguardFiles "consumer-rules.pro"
+        multiDexEnabled true
     }
 
     flavorDimensions "target"
@@ -218,7 +221,7 @@ task platformUnitTestJacocoReport(type: JacocoReport, dependsOn: "testPhoneDebug
     additionalClassDirs.setFrom files([debugTree])
     additionalSourceDirs.setFrom files(android.sourceSets.main.java.sourceFiles)
     sourceDirectories.setFrom files(android.sourceSets.phone.java.sourceFiles)
-    executionData "$buildDir/jacoco/testPhoneDebugUnitTest.exec"
+    executionData "$buildDir/outputs/unit_test_code_coverage/phoneDebugUnitTest/testPhoneDebugUnitTest.exec"
 
     reports {
         xml.enabled true
@@ -259,6 +262,7 @@ dependencies {
     testImplementation 'org.powermock:powermock-module-junit4:2.0.0'
     testImplementation 'org.json:json:20180813'
 
+    androidTestImplementation "androidx.test:core:1.4.0"
     androidTestImplementation "androidx.test.ext:junit:${rootProject.ext.junitVersion}"
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     // Using older version of PowerMock as it supports minimum Android API < 26

--- a/code/edgeidentity/build.gradle
+++ b/code/edgeidentity/build.gradle
@@ -28,8 +28,8 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.minSdkVersion
-        targetSdkVersion rootProject.ext.targetSdkVersion
+        minSdk rootProject.ext.minSdkVersion
+        targetSdk rootProject.ext.targetSdkVersion
 
         testInstrumentationRunner rootProject.ext.testInstrumentationRunner
         consumerProguardFiles "consumer-rules.pro"
@@ -46,6 +46,7 @@ android {
     buildTypes {
         debug {
             testCoverageEnabled true
+            debuggable true
         }
 
         release {
@@ -116,39 +117,6 @@ publish.dependsOn('assemblePhone')
 
 publishing {
     publications {
-        aar(MavenPublication) {
-            groupId = 'com.adobe.marketing.mobile'
-            artifactId = rootProject.moduleName
-            version = rootProject.moduleVersion
-            artifact("$buildDir/outputs/aar/${rootProject.moduleAARName}")
-            artifact javadocPublish
-            pom.withXml {
-                asNode().appendNode('name', mavenRepoName)
-                asNode().appendNode('description', mavenRepoDescription)
-                asNode().appendNode('url', 'https://aep-sdks.gitbook.io/docs/')
-                def scmNode = asNode().appendNode('scm')
-                scmNode.appendNode('url', 'https://github.com/Adobe-Marketing-Cloud/acp-sdks/')
-
-
-                def developersNode = asNode().appendNode('developers')
-                def developerNode = developersNode.appendNode('developer')
-                developerNode.appendNode('id', 'adobe')
-                developerNode.appendNode('name', 'adobe')
-
-                def licensesNode = asNode().appendNode('licenses')
-                def licenseNode = licensesNode.appendNode('license')
-                licenseNode.appendNode('name', 'Adobe Proprietary')
-
-                def dependenciesNode = asNode().appendNode('dependencies')
-
-                //Iterate over the compile dependencies (we don't want the test ones), adding a <dependency> node for each
-
-                def coreDependencyNode = dependenciesNode.appendNode('dependency')
-                coreDependencyNode.appendNode('groupId', 'com.adobe.marketing.mobile')
-                coreDependencyNode.appendNode('artifactId', 'core')
-                coreDependencyNode.appendNode('version', mavenCoreVersion)
-            }
-        }
         release(MavenPublication) {
             groupId = 'com.adobe.marketing.mobile'
             artifactId = rootProject.moduleName
@@ -224,14 +192,14 @@ task platformUnitTestJacocoReport(type: JacocoReport, dependsOn: "testPhoneDebug
     executionData "$buildDir/outputs/unit_test_code_coverage/phoneDebugUnitTest/testPhoneDebugUnitTest.exec"
 
     reports {
-        xml.enabled true
-        csv.enabled false
-        html.enabled true
+        xml.required = true
+        csv.required = false
+        html.required = true
     }
 }
 
 task platformFunctionalTestJacocoReport(type: JacocoReport, dependsOn: "createPhoneDebugCoverageReport") {
-    def excludeRegex = ['**/ADB*.class', '**/BuildConfig.class']
+    def excludeRegex = ['**/BuildConfig.class']
     def debugTree = fileTree(dir: "${project.buildDir}/intermediates/javac/phoneDebug/classes/com/adobe/marketing/mobile", excludes: excludeRegex)
 
     additionalClassDirs.setFrom files([debugTree])
@@ -242,12 +210,11 @@ task platformFunctionalTestJacocoReport(type: JacocoReport, dependsOn: "createPh
     ])
 
     reports {
-        xml.enabled true
-        csv.enabled false
-        html.enabled true
+        xml.required = true
+        csv.required = false
+        html.required = true
     }
 }
-
 
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'

--- a/code/edgeidentity/src/main/AndroidManifest.xml
+++ b/code/edgeidentity/src/main/AndroidManifest.xml
@@ -1,3 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.adobe.marketing.mobile.edge.identity">
-</manifest>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"/>

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -4,6 +4,7 @@ org.gradle.jvmargs=-Xmx2048m
 
 android.useAndroidX=true
 android.enableJetifier=true
+android.disableAutomaticComponentCreation=true
 
 moduleProjectName=edgeidentity
 moduleName=edgeidentity

--- a/code/gradle/wrapper/gradle-wrapper.properties
+++ b/code/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Mar 18 11:50:52 PDT 2022
+#Mon Nov 07 08:48:57 PST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/code/settings.gradle
+++ b/code/settings.gradle
@@ -1,3 +1,20 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+        maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
+    }
+}
+
 include ':app'
 include ':edgeidentity'
 rootProject.name = "edgeidentity-sdk"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Upgraded tools & dependancies 
   - Gradle distribution 7.5
   - Gradle 7.3.0
   - Java 1.8
   - Kotlin 1.6.21
   - jacoco 0.8.8
- Expanded .gitignore to include more files.
- Restructure plugin declarations

<!--- Describe your changes in detail -->

## Related Issue
[MOB-17088](https://jira.corp.adobe.com/browse/MOB-17088)

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Upgrade tools and dependancies in preparation for Android Core 2.0 adoption. 

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Verified that `ci-build` , `ci-javadoc` `ci-unit-test` `ci-funtional-test`pass locally.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
N/A
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
