### PR TITLE
Adopt Log service and DataStoreService changes from Core 2.0

### DIFF
--- a/code/edgeidentity/src/androidTest/java/com/adobe/marketing/mobile/MonitorExtension.java
+++ b/code/edgeidentity/src/androidTest/java/com/adobe/marketing/mobile/MonitorExtension.java
@@ -140,7 +140,7 @@ class MonitorExtension extends Extension {
 
 		EventSpec eventSpec = new EventSpec(event.getSource(), event.getType());
 
-		MobileCore.log(LoggingMode.DEBUG, LOG_TAG, "Received and processing event " + eventSpec);
+		Log.debug(LOG_TAG, TAG, "Received and processing event " + eventSpec);
 
 		if (!receivedEvents.containsKey(eventSpec)) {
 			receivedEvents.put(eventSpec, new ArrayList<Event>());
@@ -158,7 +158,7 @@ class MonitorExtension extends Extension {
 	 * @param event
 	 */
 	private void processUnregisterRequest(final Event event) {
-		MobileCore.log(LoggingMode.DEBUG, LOG_TAG, "Unregistering the Monitor Extension.");
+		Log.debug(LOG_TAG, TAG, "Unregistering the Monitor Extension.");
 		getApi().unregisterExtension();
 	}
 

--- a/code/edgeidentity/src/androidTest/java/com/adobe/marketing/mobile/MonitorExtension.java
+++ b/code/edgeidentity/src/androidTest/java/com/adobe/marketing/mobile/MonitorExtension.java
@@ -140,7 +140,7 @@ class MonitorExtension extends Extension {
 
 		EventSpec eventSpec = new EventSpec(event.getSource(), event.getType());
 
-		Log.debug(LOG_TAG, TAG, "Received and processing event " + eventSpec);
+		MobileCore.log(LoggingMode.DEBUG, LOG_TAG, "Received and processing event " + eventSpec);
 
 		if (!receivedEvents.containsKey(eventSpec)) {
 			receivedEvents.put(eventSpec, new ArrayList<Event>());
@@ -158,7 +158,7 @@ class MonitorExtension extends Extension {
 	 * @param event
 	 */
 	private void processUnregisterRequest(final Event event) {
-		Log.debug(LOG_TAG, TAG, "Unregistering the Monitor Extension.");
+		MobileCore.log(LoggingMode.DEBUG, LOG_TAG, "Unregistering the Monitor Extension.");
 		getApi().unregisterExtension();
 	}
 

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/ECID.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/ECID.java
@@ -11,6 +11,8 @@
 
 package com.adobe.marketing.mobile.edge.identity;
 
+import static com.adobe.marketing.mobile.edge.identity.IdentityConstants.LOG_TAG;
+
 import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.util.StringUtils;
 import java.util.Locale;
@@ -45,7 +47,7 @@ final class ECID {
 	ECID(final String ecidString) {
 		if (StringUtils.isNullOrEmpty(ecidString)) {
 			Log.debug(
-				IdentityConstants.LOG_TAG,
+				LOG_TAG,
 				LOG_SOURCE,
 				"Creating an ECID with null or empty ecidString is not allowed, generating a new ECID."
 			);

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/ECID.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/ECID.java
@@ -11,8 +11,7 @@
 
 package com.adobe.marketing.mobile.edge.identity;
 
-import com.adobe.marketing.mobile.LoggingMode;
-import com.adobe.marketing.mobile.MobileCore;
+import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.util.StringUtils;
 import java.util.Locale;
 import java.util.Objects;
@@ -22,6 +21,8 @@ import java.util.UUID;
  * This class represents an ECID
  */
 final class ECID {
+
+	private static final String LOG_SOURCE = "ECID";
 
 	private final String ecidString;
 
@@ -43,9 +44,9 @@ final class ECID {
 	 */
 	ECID(final String ecidString) {
 		if (StringUtils.isNullOrEmpty(ecidString)) {
-			MobileCore.log(
-				LoggingMode.DEBUG,
+			Log.debug(
 				IdentityConstants.LOG_TAG,
+				LOG_SOURCE,
 				"Creating an ECID with null or empty ecidString is not allowed, generating a new ECID."
 			);
 			this.ecidString = new ECID().toString();

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/Identity.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/Identity.java
@@ -20,8 +20,8 @@ import com.adobe.marketing.mobile.Event;
 import com.adobe.marketing.mobile.Extension;
 import com.adobe.marketing.mobile.ExtensionError;
 import com.adobe.marketing.mobile.ExtensionErrorCallback;
-import com.adobe.marketing.mobile.LoggingMode;
 import com.adobe.marketing.mobile.MobileCore;
+import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.util.DataReader;
 import com.adobe.marketing.mobile.util.StringUtils;
 import java.util.HashMap;
@@ -35,6 +35,8 @@ public class Identity {
 
 	public static final Class<? extends Extension> EXTENSION = IdentityExtension.class;
 	private static final long CALLBACK_TIMEOUT_MILLIS = 500L;
+
+	private static final String LOG_SOURCE = "Identity";
 
 	private Identity() {}
 
@@ -59,11 +61,10 @@ public class Identity {
 			new ExtensionErrorCallback<ExtensionError>() {
 				@Override
 				public void error(ExtensionError extensionError) {
-					MobileCore.log(
-						LoggingMode.ERROR,
+					Log.error(
 						LOG_TAG,
-						"Identity - There was an error registering the Edge Identity extension: " +
-						extensionError.getErrorName()
+						LOG_SOURCE,
+						"There was an error registering the Edge Identity extension: " + extensionError.getErrorName()
 					);
 				}
 			}
@@ -79,11 +80,7 @@ public class Identity {
 	 */
 	public static void getExperienceCloudId(final AdobeCallback<String> callback) {
 		if (callback == null) {
-			MobileCore.log(
-				LoggingMode.DEBUG,
-				LOG_TAG,
-				"Identity - Unexpected null callback, provide a callback to retrieve current ECID."
-			);
+			Log.debug(LOG_TAG, LOG_SOURCE, "Unexpected null callback, provide a callback to retrieve current ECID.");
 			return;
 		}
 
@@ -105,10 +102,10 @@ public class Identity {
 				final IdentityMap identityMap = IdentityMap.fromXDMMap(responseEvent.getEventData());
 
 				if (identityMap == null) {
-					MobileCore.log(
-						LoggingMode.DEBUG,
+					Log.debug(
 						LOG_TAG,
-						"Identity - Failed to read IdentityMap from response event, invoking error callback with AdobeError.UNEXPECTED_ERROR"
+						LOG_SOURCE,
+						"Failed to read IdentityMap from response event, invoking error callback with AdobeError.UNEXPECTED_ERROR"
 					);
 					returnError(callback, AdobeError.UNEXPECTED_ERROR);
 					return;
@@ -128,11 +125,11 @@ public class Identity {
 			@Override
 			public void fail(AdobeError adobeError) {
 				returnError(callback, adobeError);
-				MobileCore.log(
-					LoggingMode.DEBUG,
+				Log.debug(
 					LOG_TAG,
+					LOG_SOURCE,
 					String.format(
-						"Identity - Failed to dispatch %s event: Error : %s.",
+						"Failed to dispatch %s event: Error : %s.",
 						IdentityConstants.EventNames.IDENTITY_REQUEST_IDENTITY_ECID,
 						adobeError.getErrorName()
 					)
@@ -162,10 +159,10 @@ public class Identity {
 	 */
 	public static void getUrlVariables(final AdobeCallback<String> callback) {
 		if (callback == null) {
-			MobileCore.log(
-				LoggingMode.DEBUG,
+			Log.debug(
 				LOG_TAG,
-				"Identity - Unexpected null callback, provide a callback to retrieve current visitor identifiers (URLVariables) query string."
+				LOG_SOURCE,
+				"Unexpected null callback, provide a callback to retrieve current visitor identifiers (URLVariables) query string."
 			);
 			return;
 		}
@@ -209,11 +206,11 @@ public class Identity {
 			@Override
 			public void fail(final AdobeError adobeError) {
 				returnError(callback, adobeError);
-				MobileCore.log(
-					LoggingMode.DEBUG,
+				Log.debug(
 					LOG_TAG,
+					LOG_SOURCE,
 					String.format(
-						"Identity - Failed to dispatch %s event: Error : %s.",
+						"Failed to dispatch %s event: Error : %s.",
 						IdentityConstants.EventNames.IDENTITY_REQUEST_URL_VARIABLES,
 						adobeError.getErrorName()
 					)
@@ -234,11 +231,7 @@ public class Identity {
 	 */
 	public static void updateIdentities(final IdentityMap identityMap) {
 		if (identityMap == null || identityMap.isEmpty()) {
-			MobileCore.log(
-				LoggingMode.DEBUG,
-				LOG_TAG,
-				"Identity - Unable to updateIdentities, IdentityMap is null or empty"
-			);
+			Log.debug(LOG_TAG, LOG_SOURCE, "Unable to updateIdentities, IdentityMap is null or empty");
 			return;
 		}
 
@@ -262,16 +255,12 @@ public class Identity {
 	 */
 	public static void removeIdentity(final IdentityItem item, final String namespace) {
 		if (StringUtils.isNullOrEmpty(namespace)) {
-			MobileCore.log(
-				LoggingMode.DEBUG,
-				LOG_TAG,
-				"Identity - Unable to removeIdentity, namespace is null or empty"
-			);
+			Log.debug(LOG_TAG, LOG_SOURCE, "Unable to removeIdentity, namespace is null or empty");
 			return;
 		}
 
 		if (item == null) {
-			MobileCore.log(LoggingMode.DEBUG, LOG_TAG, "Identity - Unable to removeIdentity, IdentityItem is null");
+			Log.debug(LOG_TAG, LOG_SOURCE, "Unable to removeIdentity, IdentityItem is null");
 			return;
 		}
 
@@ -297,10 +286,10 @@ public class Identity {
 	 */
 	public static void getIdentities(final AdobeCallback<IdentityMap> callback) {
 		if (callback == null) {
-			MobileCore.log(
-				LoggingMode.DEBUG,
+			Log.debug(
 				LOG_TAG,
-				"Identity - Unexpected null callback, provide a callback to retrieve current IdentityMap."
+				LOG_SOURCE,
+				"Unexpected null callback, provide a callback to retrieve current IdentityMap."
 			);
 			return;
 		}
@@ -323,10 +312,10 @@ public class Identity {
 				final IdentityMap identityMap = IdentityMap.fromXDMMap(responseEvent.getEventData());
 
 				if (identityMap == null) {
-					MobileCore.log(
-						LoggingMode.DEBUG,
+					Log.debug(
 						LOG_TAG,
-						"Identity - Failed to read IdentityMap from response event, invoking error callback with AdobeError.UNEXPECTED_ERROR"
+						LOG_SOURCE,
+						"Failed to read IdentityMap from response event, invoking error callback with AdobeError.UNEXPECTED_ERROR"
 					);
 					returnError(callback, AdobeError.UNEXPECTED_ERROR);
 					return;
@@ -338,11 +327,11 @@ public class Identity {
 			@Override
 			public void fail(final AdobeError adobeError) {
 				returnError(callback, adobeError);
-				MobileCore.log(
-					LoggingMode.DEBUG,
+				Log.debug(
 					LOG_TAG,
+					LOG_SOURCE,
 					String.format(
-						"Identity - Failed to dispatch %s event: Error : %s.",
+						"Failed to dispatch %s event: Error : %s.",
 						IdentityConstants.EventNames.REQUEST_IDENTITIES,
 						adobeError.getErrorName()
 					)

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityExtension.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityExtension.java
@@ -18,11 +18,10 @@ import androidx.annotation.VisibleForTesting;
 import com.adobe.marketing.mobile.Event;
 import com.adobe.marketing.mobile.Extension;
 import com.adobe.marketing.mobile.ExtensionApi;
-import com.adobe.marketing.mobile.LoggingMode;
-import com.adobe.marketing.mobile.MobileCore;
 import com.adobe.marketing.mobile.SharedStateResolution;
 import com.adobe.marketing.mobile.SharedStateResult;
 import com.adobe.marketing.mobile.SharedStateStatus;
+import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.util.StringUtils;
 import com.adobe.marketing.mobile.util.TimeUtils;
 import java.util.HashMap;
@@ -190,7 +189,7 @@ class IdentityExtension extends Extension {
 			handleUrlVariableResponse(
 				event,
 				null,
-				"IdentityExtension - Cannot process getUrlVariables request Identity event, Experience Cloud Org ID not found in configuration."
+				"Cannot process getUrlVariables request Identity event, Experience Cloud Org ID not found in configuration."
 			);
 			return;
 		}
@@ -202,7 +201,7 @@ class IdentityExtension extends Extension {
 			handleUrlVariableResponse(
 				event,
 				null,
-				"IdentityExtension - Cannot process getUrlVariables request Identity event, ECID not found."
+				"Cannot process getUrlVariables request Identity event, ECID not found."
 			);
 			return;
 		}
@@ -250,7 +249,7 @@ class IdentityExtension extends Extension {
 			.build();
 
 		if (StringUtils.isNullOrEmpty(urlVariables) && !StringUtils.isNullOrEmpty(errorMsg)) {
-			MobileCore.log(LoggingMode.WARNING, LOG_TAG, errorMsg);
+			Log.warning(LOG_TAG, LOG_TAG, errorMsg);
 		}
 
 		getApi().dispatch(responseEvent);
@@ -269,11 +268,7 @@ class IdentityExtension extends Extension {
 		final IdentityMap map = IdentityMap.fromXDMMap(eventData);
 
 		if (map == null) {
-			MobileCore.log(
-				LoggingMode.DEBUG,
-				LOG_TAG,
-				"IdentityExtension - Failed to update identifiers as no identifiers were found in the event data."
-			);
+			Log.debug(LOG_TAG, LOG_TAG, "Failed to update identifiers as no identifiers were found in the event data.");
 			return;
 		}
 
@@ -294,11 +289,7 @@ class IdentityExtension extends Extension {
 		final IdentityMap map = IdentityMap.fromXDMMap(eventData);
 
 		if (map == null) {
-			MobileCore.log(
-				LoggingMode.DEBUG,
-				LOG_TAG,
-				"IdentityExtension - Failed to remove identifiers as no identifiers were found in the event data."
-			);
+			Log.debug(LOG_TAG, LOG_TAG, "Failed to remove identifiers as no identifiers were found in the event data.");
 			return;
 		}
 

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityExtension.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityExtension.java
@@ -54,7 +54,7 @@ class IdentityExtension extends Extension {
 	 * @param extensionApi {@link ExtensionApi} instance
 	 */
 	protected IdentityExtension(ExtensionApi extensionApi) {
-		this(extensionApi, new IdentityState());
+		this(extensionApi, new IdentityState(new IdentityStorageManager()));
 	}
 
 	@VisibleForTesting

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityExtension.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityExtension.java
@@ -22,12 +22,15 @@ import com.adobe.marketing.mobile.SharedStateResolution;
 import com.adobe.marketing.mobile.SharedStateResult;
 import com.adobe.marketing.mobile.SharedStateStatus;
 import com.adobe.marketing.mobile.services.Log;
+import com.adobe.marketing.mobile.services.ServiceProvider;
 import com.adobe.marketing.mobile.util.StringUtils;
 import com.adobe.marketing.mobile.util.TimeUtils;
 import java.util.HashMap;
 import java.util.Map;
 
 class IdentityExtension extends Extension {
+
+	private static final String LOG_SOURCE = "IdentityExtension";
 
 	/**
 	 * A {@code SharedStateCallback} to retrieve the last set state of an extension and to
@@ -54,7 +57,7 @@ class IdentityExtension extends Extension {
 	 * @param extensionApi {@link ExtensionApi} instance
 	 */
 	protected IdentityExtension(ExtensionApi extensionApi) {
-		this(extensionApi, new IdentityState(new IdentityStorageManager()));
+		this(extensionApi, new IdentityState(ServiceProvider.getInstance().getDataStoreService()));
 	}
 
 	@VisibleForTesting
@@ -249,7 +252,7 @@ class IdentityExtension extends Extension {
 			.build();
 
 		if (StringUtils.isNullOrEmpty(urlVariables) && !StringUtils.isNullOrEmpty(errorMsg)) {
-			Log.warning(LOG_TAG, LOG_TAG, errorMsg);
+			Log.warning(LOG_TAG, LOG_SOURCE, errorMsg);
 		}
 
 		getApi().dispatch(responseEvent);
@@ -263,12 +266,19 @@ class IdentityExtension extends Extension {
 	void handleUpdateIdentities(@NonNull final Event event) {
 		final Map<String, Object> eventData = event.getEventData();
 
-		if (eventData == null) return; // TODO: Add log message when logging changes are made
+		if (eventData == null) {
+			Log.debug(LOG_TAG, LOG_SOURCE, "Cannot update identifiers, event data is null.");
+			return;
+		}
 
 		final IdentityMap map = IdentityMap.fromXDMMap(eventData);
 
 		if (map == null) {
-			Log.debug(LOG_TAG, LOG_TAG, "Failed to update identifiers as no identifiers were found in the event data.");
+			Log.debug(
+				LOG_TAG,
+				LOG_SOURCE,
+				"Failed to update identifiers as no identifiers were found in the event data."
+			);
 			return;
 		}
 
@@ -284,12 +294,19 @@ class IdentityExtension extends Extension {
 	void handleRemoveIdentity(@NonNull final Event event) {
 		final Map<String, Object> eventData = event.getEventData();
 
-		if (eventData == null) return; // TODO: Add log message when logging changes are made
+		if (eventData == null) {
+			Log.debug(LOG_TAG, LOG_SOURCE, "Cannot remove identifiers, event data is null.");
+			return;
+		}
 
 		final IdentityMap map = IdentityMap.fromXDMMap(eventData);
 
 		if (map == null) {
-			Log.debug(LOG_TAG, LOG_TAG, "Failed to remove identifiers as no identifiers were found in the event data.");
+			Log.debug(
+				LOG_TAG,
+				LOG_SOURCE,
+				"Failed to remove identifiers as no identifiers were found in the event data."
+			);
 			return;
 		}
 

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityExtension.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityExtension.java
@@ -57,7 +57,7 @@ class IdentityExtension extends Extension {
 	 * @param extensionApi {@link ExtensionApi} instance
 	 */
 	protected IdentityExtension(ExtensionApi extensionApi) {
-		this(extensionApi, new IdentityState(ServiceProvider.getInstance().getDataStoreService()));
+		this(extensionApi, new IdentityState());
 	}
 
 	@VisibleForTesting
@@ -267,7 +267,7 @@ class IdentityExtension extends Extension {
 		final Map<String, Object> eventData = event.getEventData();
 
 		if (eventData == null) {
-			Log.debug(LOG_TAG, LOG_SOURCE, "Cannot update identifiers, event data is null.");
+			Log.trace(LOG_TAG, LOG_SOURCE, "Cannot update identifiers, event data is null.");
 			return;
 		}
 
@@ -295,7 +295,7 @@ class IdentityExtension extends Extension {
 		final Map<String, Object> eventData = event.getEventData();
 
 		if (eventData == null) {
-			Log.debug(LOG_TAG, LOG_SOURCE, "Cannot remove identifiers, event data is null.");
+			Log.trace(LOG_TAG, LOG_SOURCE, "Cannot remove identifiers, event data is null.");
 			return;
 		}
 

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityItem.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityItem.java
@@ -13,8 +13,7 @@ package com.adobe.marketing.mobile.edge.identity;
 
 import static com.adobe.marketing.mobile.edge.identity.IdentityConstants.LOG_TAG;
 
-import com.adobe.marketing.mobile.LoggingMode;
-import com.adobe.marketing.mobile.MobileCore;
+import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.util.DataReader;
 import com.adobe.marketing.mobile.util.DataReaderException;
 import java.util.HashMap;
@@ -28,6 +27,8 @@ import java.util.Objects;
  * @see <a href="https://github.com/adobe/xdm/blob/master/docs/reference/datatypes/identityitem.schema.md">Identity Item Schema</a>
  */
 public final class IdentityItem {
+
+	private static final String LOG_SOURCE = "IdentityItem";
 
 	private final String id;
 	private final AuthenticatedState authenticatedState;
@@ -182,7 +183,7 @@ public final class IdentityItem {
 
 			return new IdentityItem(id, authenticatedState, primary);
 		} catch (final DataReaderException e) {
-			MobileCore.log(LoggingMode.DEBUG, LOG_TAG, "IdentityItem - Failed to create IdentityItem from data.");
+			Log.debug(LOG_TAG, LOG_SOURCE, "Failed to create IdentityItem from data.");
 			return null;
 		}
 	}

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityMap.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityMap.java
@@ -13,8 +13,7 @@ package com.adobe.marketing.mobile.edge.identity;
 
 import static com.adobe.marketing.mobile.edge.identity.IdentityConstants.LOG_TAG;
 
-import com.adobe.marketing.mobile.LoggingMode;
-import com.adobe.marketing.mobile.MobileCore;
+import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.util.DataReader;
 import com.adobe.marketing.mobile.util.StringUtils;
 import java.util.ArrayList;
@@ -32,6 +31,8 @@ import java.util.Map;
  */
 @SuppressWarnings("unused")
 public class IdentityMap {
+
+	private static final String LOG_SOURCE = "IdentityMap";
 
 	private final Map<String, List<IdentityItem>> identityItems = new HashMap<>();
 
@@ -90,20 +91,12 @@ public class IdentityMap {
 	 */
 	public void removeItem(final IdentityItem item, final String namespace) {
 		if (item == null) {
-			MobileCore.log(
-				LoggingMode.DEBUG,
-				LOG_TAG,
-				"IdentityMap remove item ignored as must contain a non-null IdentityItem."
-			);
+			Log.debug(LOG_TAG, LOG_SOURCE, "Remove item ignored as must contain a non-null IdentityItem.");
 			return;
 		}
 
 		if (StringUtils.isNullOrEmpty(namespace)) {
-			MobileCore.log(
-				LoggingMode.DEBUG,
-				LOG_TAG,
-				"IdentityMap remove item ignored as must contain a non-null/non-empty namespace."
-			);
+			Log.debug(LOG_TAG, LOG_SOURCE, "Remove item ignored as must contain a non-null/non-empty namespace.");
 			return;
 		}
 
@@ -161,20 +154,12 @@ public class IdentityMap {
 	 */
 	void addItem(final IdentityItem item, final String namespace, final boolean isFirstItem) {
 		if (item == null) {
-			MobileCore.log(
-				LoggingMode.DEBUG,
-				LOG_TAG,
-				"IdentityMap - add item ignored as must contain a non-null IdentityItem."
-			);
+			Log.debug(LOG_TAG, LOG_SOURCE, "Add item ignored as must contain a non-null IdentityItem.");
 			return;
 		}
 
 		if (StringUtils.isNullOrEmpty(namespace)) {
-			MobileCore.log(
-				LoggingMode.DEBUG,
-				LOG_TAG,
-				"IdentityMap - add item ignored as must contain a non-null/non-empty namespace."
-			);
+			Log.debug(LOG_TAG, LOG_SOURCE, "Add item ignored as must contain a non-null/non-empty namespace.");
 			return;
 		}
 

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityProperties.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityProperties.java
@@ -13,10 +13,9 @@ package com.adobe.marketing.mobile.edge.identity;
 
 import static com.adobe.marketing.mobile.edge.identity.IdentityConstants.LOG_TAG;
 
-import com.adobe.marketing.mobile.LoggingMode;
-import com.adobe.marketing.mobile.MobileCore;
+import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.util.StringUtils;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -25,13 +24,12 @@ import java.util.Map;
  */
 class IdentityProperties {
 
-	private static final List<String> reservedNamespaces = new ArrayList<String>() {
-		{
-			add(IdentityConstants.Namespaces.ECID);
-			add(IdentityConstants.Namespaces.GAID);
-			add(IdentityConstants.Namespaces.IDFA);
-		}
-	};
+	private static final String LOG_SOURCE = "IdentityProperties";
+	private static final List<String> reservedNamespaces = Arrays.asList(
+		IdentityConstants.Namespaces.ECID,
+		IdentityConstants.Namespaces.GAID,
+		IdentityConstants.Namespaces.IDFA
+	);
 
 	private final IdentityMap identityMap;
 
@@ -155,7 +153,7 @@ class IdentityProperties {
 
 		// do not set secondary ECID if primary ECID is not set
 		if (getECID() == null) {
-			MobileCore.log(LoggingMode.DEBUG, LOG_TAG, "Cannot set secondary ECID value as no primary ECID exists.");
+			Log.debug(LOG_TAG, LOG_SOURCE, "Cannot set secondary ECID value as no primary ECID exists.");
 			return;
 		}
 
@@ -248,20 +246,20 @@ class IdentityProperties {
 					reservedNamespace.equalsIgnoreCase(IdentityConstants.Namespaces.GAID) ||
 					reservedNamespace.equalsIgnoreCase(IdentityConstants.Namespaces.IDFA)
 				) {
-					MobileCore.log(
-						LoggingMode.DEBUG,
+					Log.debug(
 						LOG_TAG,
+						LOG_SOURCE,
 						String.format(
-							"IdentityProperties - Operation not allowed for namespace %s; use MobileCore.setAdvertisingIdentifier instead.",
+							"Operation not allowed for namespace %s; use MobileCore.setAdvertisingIdentifier instead.",
 							reservedNamespace
 						)
 					);
 				} else {
-					MobileCore.log(
-						LoggingMode.DEBUG,
+					Log.debug(
 						LOG_TAG,
+						LOG_SOURCE,
 						String.format(
-							"IdentityProperties - Updating/Removing identifiers in namespace %s is not allowed.",
+							"Updating/Removing identifiers in namespace %s is not allowed.",
 							reservedNamespace
 						)
 					);

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityState.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityState.java
@@ -18,6 +18,7 @@ import com.adobe.marketing.mobile.Event;
 import com.adobe.marketing.mobile.MobileCore;
 import com.adobe.marketing.mobile.SharedStateResult;
 import com.adobe.marketing.mobile.SharedStateStatus;
+import com.adobe.marketing.mobile.services.DataStoring;
 import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.util.DataReader;
 import java.util.HashMap;
@@ -34,9 +35,14 @@ class IdentityState {
 	private IdentityProperties identityProperties;
 	private boolean hasBooted;
 
+	IdentityState(final DataStoring dataStoreService) {
+		this(new IdentityStorageManager(dataStoreService));
+	}
+
 	/**
 	 * Loads the persisted identities (if any) into {@link #identityProperties}
 	 */
+	@VisibleForTesting
 	IdentityState(final IdentityStorageManager identityStorageManager) {
 		this.identityStorageManager = identityStorageManager;
 

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityState.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityState.java
@@ -20,6 +20,7 @@ import com.adobe.marketing.mobile.SharedStateResult;
 import com.adobe.marketing.mobile.SharedStateStatus;
 import com.adobe.marketing.mobile.services.DataStoring;
 import com.adobe.marketing.mobile.services.Log;
+import com.adobe.marketing.mobile.services.ServiceProvider;
 import com.adobe.marketing.mobile.util.DataReader;
 import java.util.HashMap;
 import java.util.Map;
@@ -35,8 +36,8 @@ class IdentityState {
 	private IdentityProperties identityProperties;
 	private boolean hasBooted;
 
-	IdentityState(final DataStoring dataStoreService) {
-		this(new IdentityStorageManager(dataStoreService));
+	IdentityState() {
+		this(new IdentityStorageManager(ServiceProvider.getInstance().getDataStoreService()));
 	}
 
 	/**
@@ -294,7 +295,7 @@ class IdentityState {
 		final Map<String, Object> identityDirectInfo = DataReader.optTypedMap(
 			Object.class,
 			extensions,
-			IdentityConstants.SharedState.Hub.EXTENSIONS,
+			IdentityConstants.SharedState.IdentityDirect.NAME,
 			null
 		);
 

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityState.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityState.java
@@ -15,10 +15,10 @@ import static com.adobe.marketing.mobile.edge.identity.IdentityConstants.LOG_TAG
 
 import androidx.annotation.VisibleForTesting;
 import com.adobe.marketing.mobile.Event;
-import com.adobe.marketing.mobile.LoggingMode;
 import com.adobe.marketing.mobile.MobileCore;
 import com.adobe.marketing.mobile.SharedStateResult;
 import com.adobe.marketing.mobile.SharedStateStatus;
+import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.util.DataReader;
 import java.util.HashMap;
 import java.util.Map;
@@ -27,6 +27,8 @@ import java.util.Map;
  * Manages the business logic of this Identity extension
  */
 class IdentityState {
+
+	private static final String LOG_SOURCE = "IdentityState";
 
 	private IdentityProperties identityProperties;
 	private boolean hasBooted;
@@ -97,12 +99,10 @@ class IdentityState {
 
 			if (directIdentityEcid != null) {
 				identityProperties.setECID(directIdentityEcid);
-				MobileCore.log(
-					LoggingMode.DEBUG,
+				Log.debug(
 					LOG_TAG,
-					"IdentityState -  On bootup Loading ECID from direct Identity extension '" +
-					directIdentityEcid +
-					"'"
+					LOG_SOURCE,
+					"On bootup Loading ECID from direct Identity extension '" + directIdentityEcid + "'"
 				);
 			}
 			// If direct Identity has no persisted ECID, check if direct Identity is registered with the SDK
@@ -115,10 +115,10 @@ class IdentityState {
 
 				// If there is no direct Identity shared state, abort boot-up and try again when direct Identity shares its state
 				if (sharedStateResult == null || sharedStateResult.getStatus() != SharedStateStatus.SET) {
-					MobileCore.log(
-						LoggingMode.DEBUG,
+					Log.debug(
 						LOG_TAG,
-						"IdentityState - On bootup direct Identity extension is registered, waiting for its state change."
+						LOG_SOURCE,
+						"On bootup direct Identity extension is registered, waiting for its state change."
 					);
 					return false;
 				}
@@ -129,10 +129,10 @@ class IdentityState {
 			// Generate a new ECID as the direct Identity extension is not registered with the SDK and there was no direct Identity persisted ECID
 			else {
 				identityProperties.setECID(new ECID());
-				MobileCore.log(
-					LoggingMode.DEBUG,
+				Log.debug(
 					LOG_TAG,
-					"IdentityState - Generating new ECID on bootup '" + identityProperties.getECID().toString() + "'"
+					LOG_SOURCE,
+					"Generating new ECID on bootup '" + identityProperties.getECID().toString() + "'"
 				);
 			}
 
@@ -140,7 +140,7 @@ class IdentityState {
 		}
 
 		hasBooted = true;
-		MobileCore.log(LoggingMode.DEBUG, LOG_TAG, "IdentityState - Edge Identity has successfully booted up");
+		Log.debug(LOG_TAG, LOG_SOURCE, "Edge Identity has successfully booted up");
 		callback.createXDMSharedState(identityProperties.toXDMData(false), null);
 
 		return hasBooted;
@@ -238,10 +238,10 @@ class IdentityState {
 
 		identityProperties.setECIDSecondary(legacyEcid);
 		IdentityStorageService.savePropertiesToPersistence(identityProperties);
-		MobileCore.log(
-			LoggingMode.DEBUG,
+		Log.debug(
 			LOG_TAG,
-			"IdentityState - Identity direct ECID updated to '" + legacyEcid + "', updating the IdentityMap"
+			LOG_SOURCE,
+			"Identity direct ECID updated to '" + legacyEcid + "', updating the IdentityMap"
 		);
 		return true;
 	}
@@ -256,19 +256,17 @@ class IdentityState {
 	private void handleECIDFromIdentityDirect(final ECID legacyEcid) {
 		if (legacyEcid != null) {
 			identityProperties.setECID(legacyEcid); // migrate legacy ECID
-			MobileCore.log(
-				LoggingMode.DEBUG,
+			Log.debug(
 				LOG_TAG,
-				"IdentityState - Identity direct ECID '" +
-				legacyEcid +
-				"' was migrated to Edge Identity, updating the IdentityMap"
+				LOG_SOURCE,
+				"Identity direct ECID '" + legacyEcid + "' " + "was migrated to Edge Identity, updating the IdentityMap"
 			);
 		} else { // opt-out scenario or an unexpected state for Identity direct, generate new ECID
 			identityProperties.setECID(new ECID());
-			MobileCore.log(
-				LoggingMode.DEBUG,
+			Log.debug(
 				LOG_TAG,
-				"IdentityState - Identity direct ECID is null, generating new ECID '" +
+				LOG_SOURCE,
+				"Identity direct ECID is null, generating new ECID '" +
 				identityProperties.getECID() +
 				"', updating the IdentityMap"
 			);

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityState.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityState.java
@@ -30,24 +30,18 @@ class IdentityState {
 
 	private static final String LOG_SOURCE = "IdentityState";
 
+	private final IdentityStorageManager identityStorageManager;
 	private IdentityProperties identityProperties;
 	private boolean hasBooted;
 
 	/**
 	 * Loads the persisted identities (if any) into {@link #identityProperties}
 	 */
-	IdentityState() {
-		this(IdentityStorageService.loadPropertiesFromPersistence());
-	}
+	IdentityState(final IdentityStorageManager identityStorageManager) {
+		this.identityStorageManager = identityStorageManager;
 
-	/**
-	 * Creates a new {@link IdentityState} with the given {@link IdentityProperties}
-	 *
-	 * @param identityProperties identity properties
-	 */
-	@VisibleForTesting
-	IdentityState(final IdentityProperties identityProperties) {
-		this.identityProperties = (identityProperties != null) ? identityProperties : new IdentityProperties();
+		final IdentityProperties persistedProperties = identityStorageManager.loadPropertiesFromPersistence();
+		this.identityProperties = (persistedProperties != null) ? persistedProperties : new IdentityProperties();
 	}
 
 	/**
@@ -95,7 +89,7 @@ class IdentityState {
 			}
 
 			// Attempt to get ECID from direct Identity persistence to migrate an existing ECID
-			final ECID directIdentityEcid = IdentityStorageService.loadEcidFromDirectIdentityPersistence();
+			final ECID directIdentityEcid = identityStorageManager.loadEcidFromDirectIdentityPersistence();
 
 			if (directIdentityEcid != null) {
 				identityProperties.setECID(directIdentityEcid);
@@ -136,7 +130,7 @@ class IdentityState {
 				);
 			}
 
-			IdentityStorageService.savePropertiesToPersistence(identityProperties);
+			identityStorageManager.savePropertiesToPersistence(identityProperties);
 		}
 
 		hasBooted = true;
@@ -153,7 +147,7 @@ class IdentityState {
 		identityProperties = new IdentityProperties();
 		identityProperties.setECID(new ECID());
 		identityProperties.setECIDSecondary(null);
-		IdentityStorageService.savePropertiesToPersistence(identityProperties);
+		identityStorageManager.savePropertiesToPersistence(identityProperties);
 	}
 
 	/**
@@ -163,7 +157,7 @@ class IdentityState {
 	 */
 	void updateCustomerIdentifiers(final IdentityMap map) {
 		identityProperties.updateCustomerIdentifiers(map);
-		IdentityStorageService.savePropertiesToPersistence(identityProperties);
+		identityStorageManager.savePropertiesToPersistence(identityProperties);
 	}
 
 	/**
@@ -173,7 +167,7 @@ class IdentityState {
 	 */
 	void removeCustomerIdentifiers(final IdentityMap map) {
 		identityProperties.removeCustomerIdentifiers(map);
-		IdentityStorageService.savePropertiesToPersistence(identityProperties);
+		identityStorageManager.savePropertiesToPersistence(identityProperties);
 	}
 
 	/**
@@ -212,7 +206,7 @@ class IdentityState {
 		}
 
 		// Save to persistence
-		IdentityStorageService.savePropertiesToPersistence(identityProperties);
+		identityStorageManager.savePropertiesToPersistence(identityProperties);
 		callback.createXDMSharedState(identityProperties.toXDMData(false), event);
 	}
 
@@ -237,7 +231,7 @@ class IdentityState {
 		}
 
 		identityProperties.setECIDSecondary(legacyEcid);
-		IdentityStorageService.savePropertiesToPersistence(identityProperties);
+		identityStorageManager.savePropertiesToPersistence(identityProperties);
 		Log.debug(
 			LOG_TAG,
 			LOG_SOURCE,

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityStorageManager.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityStorageManager.java
@@ -19,6 +19,7 @@ import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.services.NamedCollection;
 import com.adobe.marketing.mobile.services.ServiceProvider;
 import com.adobe.marketing.mobile.util.JSONUtils;
+import com.adobe.marketing.mobile.util.StringUtils;
 import java.util.Map;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -128,10 +129,6 @@ class IdentityStorageManager {
 			null
 		);
 
-		if (ecidString == null || ecidString.isEmpty()) {
-			return null;
-		}
-
-		return new ECID(ecidString);
+		return StringUtils.isNullOrEmpty(ecidString) ? null : new ECID(ecidString);
 	}
 }

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityStorageManager.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityStorageManager.java
@@ -83,7 +83,7 @@ class IdentityStorageManager {
 	}
 
 	/**
-	 * Saves the properties to local storage
+	 * Saves identity properties to local storage.
 	 *
 	 * @param properties properties to be stored
 	 */

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityStorageManager.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityStorageManager.java
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Adobe. All rights reserved.
+  Copyright 2022 Adobe. All rights reserved.
   This file is licensed to you under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License. You may obtain a copy
   of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -13,11 +13,9 @@ package com.adobe.marketing.mobile.edge.identity;
 
 import static com.adobe.marketing.mobile.edge.identity.IdentityConstants.LOG_TAG;
 
-import androidx.annotation.VisibleForTesting;
 import com.adobe.marketing.mobile.services.DataStoring;
 import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.services.NamedCollection;
-import com.adobe.marketing.mobile.services.ServiceProvider;
 import com.adobe.marketing.mobile.util.JSONUtils;
 import com.adobe.marketing.mobile.util.StringUtils;
 import java.util.Map;
@@ -29,15 +27,10 @@ import org.json.JSONObject;
  */
 class IdentityStorageManager {
 
-	private static final String LOG_SOURCE = "IdentityStorageService";
+	private static final String LOG_SOURCE = "IdentityStorageManager";
 	private final NamedCollection edgeIdentityStore;
 	private final NamedCollection directIdentityStore;
 
-	IdentityStorageManager() {
-		this(ServiceProvider.getInstance().getDataStoreService());
-	}
-
-	@VisibleForTesting
 	IdentityStorageManager(final DataStoring dataStoreService) {
 		this.edgeIdentityStore = dataStoreService.getNamedCollection(IdentityConstants.DataStoreKey.DATASTORE_NAME);
 		this.directIdentityStore =
@@ -47,11 +40,13 @@ class IdentityStorageManager {
 	/**
 	 * Loads identity properties from local storage, returns null if not found.
 	 *
-	 * @return properties stored in local storage if present, otherwise null.
+	 * @return {@code IdentityProperties} stored in local storage if present;
+	 *         null - if the content cannot be loaded from persistence or, if the content cannot be
+	 *         serialized to a {@code JSONObject}
 	 */
 	IdentityProperties loadPropertiesFromPersistence() {
 		if (edgeIdentityStore == null) {
-			Log.debug(
+			Log.warning(
 				LOG_TAG,
 				LOG_SOURCE,
 				"EdgeIdentity named collection is null. Unable to load saved identity properties from persistence."
@@ -90,7 +85,7 @@ class IdentityStorageManager {
 	 */
 	void savePropertiesToPersistence(final IdentityProperties properties) {
 		if (edgeIdentityStore == null) {
-			Log.debug(
+			Log.warning(
 				LOG_TAG,
 				LOG_SOURCE,
 				"EdgeIdentity named collection is null. Unable to write identity properties to persistence."

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityStorageService.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityStorageService.java
@@ -16,8 +16,8 @@ import static com.adobe.marketing.mobile.edge.identity.IdentityConstants.LOG_TAG
 import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
-import com.adobe.marketing.mobile.LoggingMode;
 import com.adobe.marketing.mobile.MobileCore;
+import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.util.JSONUtils;
 import java.util.Map;
 import org.json.JSONException;
@@ -27,6 +27,8 @@ import org.json.JSONObject;
  * Manages persistence for this Identity extension
  */
 class IdentityStorageService {
+
+	private static final String LOG_SOURCE = "IdentityStorageService";
 
 	private IdentityStorageService() {}
 
@@ -39,10 +41,10 @@ class IdentityStorageService {
 		final SharedPreferences sharedPreferences = getSharedPreference(IdentityConstants.DataStoreKey.DATASTORE_NAME);
 
 		if (sharedPreferences == null) {
-			MobileCore.log(
-				LoggingMode.DEBUG,
+			Log.debug(
 				LOG_TAG,
-				"IdentityStorageService - Shared Preference value is null. Unable to load saved identity properties from persistence."
+				LOG_SOURCE,
+				"Shared Preference value is null. Unable to load saved identity properties from persistence."
 			);
 			return null;
 		}
@@ -50,10 +52,10 @@ class IdentityStorageService {
 		final String jsonString = sharedPreferences.getString(IdentityConstants.DataStoreKey.IDENTITY_PROPERTIES, null);
 
 		if (jsonString == null) {
-			MobileCore.log(
-				LoggingMode.VERBOSE,
+			Log.debug(
 				LOG_TAG,
-				"IdentityStorageService - No previous properties were stored in persistence. Current identity properties are null"
+				LOG_SOURCE,
+				"No previous properties were stored in persistence. Current identity properties are null"
 			);
 			return null;
 		}
@@ -63,10 +65,10 @@ class IdentityStorageService {
 			final Map<String, Object> propertyMap = JSONUtils.toMap(jsonObject);
 			return new IdentityProperties(propertyMap);
 		} catch (JSONException exception) {
-			MobileCore.log(
-				LoggingMode.DEBUG,
+			Log.debug(
 				LOG_TAG,
-				"IdentityStorageService - Serialization error while reading properties jsonString from persistence. Unable to load saved identity properties from persistence."
+				LOG_SOURCE,
+				"Serialization error while reading properties jsonString from persistence. Unable to load saved identity properties from persistence."
 			);
 			return null;
 		}
@@ -81,10 +83,10 @@ class IdentityStorageService {
 		final SharedPreferences sharedPreferences = getSharedPreference(IdentityConstants.DataStoreKey.DATASTORE_NAME);
 
 		if (sharedPreferences == null) {
-			MobileCore.log(
-				LoggingMode.DEBUG,
+			Log.debug(
 				LOG_TAG,
-				"IdentityStorageService - Shared Preference value is null. Unable to write identity properties to persistence."
+				LOG_SOURCE,
+				"Shared Preference value is null. Unable to write identity properties to persistence."
 			);
 			return;
 		}
@@ -92,20 +94,16 @@ class IdentityStorageService {
 		final SharedPreferences.Editor editor = sharedPreferences.edit();
 
 		if (editor == null) {
-			MobileCore.log(
-				LoggingMode.DEBUG,
+			Log.debug(
 				LOG_TAG,
-				"IdentityStorageService - Shared Preference Editor is null. Unable to write identity properties to persistence."
+				LOG_SOURCE,
+				"Shared Preference Editor is null. Unable to write identity properties to persistence."
 			);
 			return;
 		}
 
 		if (properties == null) {
-			MobileCore.log(
-				LoggingMode.DEBUG,
-				LOG_TAG,
-				"IdentityStorageService - Identity Properties are null, removing them from persistence."
-			);
+			Log.debug(LOG_TAG, LOG_SOURCE, "Identity Properties are null, removing them from persistence.");
 			editor.remove(IdentityConstants.DataStoreKey.IDENTITY_PROPERTIES);
 			editor.apply();
 			return;
@@ -128,10 +126,10 @@ class IdentityStorageService {
 		);
 
 		if (sharedPreferences == null) {
-			MobileCore.log(
-				LoggingMode.DEBUG,
+			Log.debug(
 				LOG_TAG,
-				"IdentityStorageService - Shared Preference value is null. Unable to load saved direct identity ECID from persistence."
+				LOG_SOURCE,
+				"Shared Preference value is null. Unable to load saved direct identity ECID from persistence."
 			);
 			return null;
 		}
@@ -160,22 +158,14 @@ class IdentityStorageService {
 		final Application application = MobileCore.getApplication();
 
 		if (application == null) {
-			MobileCore.log(
-				LoggingMode.DEBUG,
-				LOG_TAG,
-				"IdentityStorageService - Application value is null. Unable to read/write data from persistence."
-			);
+			Log.debug(LOG_TAG, LOG_SOURCE, "Application value is null. Unable to read/write data from persistence.");
 			return null;
 		}
 
 		final Context context = application.getApplicationContext();
 
 		if (context == null) {
-			MobileCore.log(
-				LoggingMode.DEBUG,
-				LOG_TAG,
-				"IdentityStorageService - Context value is null. Unable to read/write data from persistence."
-			);
+			Log.debug(LOG_TAG, LOG_SOURCE, "Context value is null. Unable to read/write data from persistence.");
 			return null;
 		}
 

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/URLUtils.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/URLUtils.java
@@ -11,8 +11,9 @@
 
 package com.adobe.marketing.mobile.edge.identity;
 
-import com.adobe.marketing.mobile.LoggingMode;
-import com.adobe.marketing.mobile.MobileCore;
+import static com.adobe.marketing.mobile.edge.identity.IdentityConstants.LOG_TAG;
+
+import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.util.StringUtils;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -20,7 +21,7 @@ import java.nio.charset.StandardCharsets;
 
 class URLUtils {
 
-	static final String LOG_TAG = "URLUtils";
+	private static final String LOG_SOURCE = "URLUtils";
 
 	/**
 	 * Helper function to generate url variables in format acceptable by the AEP web SDKs
@@ -56,7 +57,7 @@ class URLUtils {
 				urlFragment.append(URLEncoder.encode(theIdString, StandardCharsets.UTF_8.toString()));
 			}
 		} catch (UnsupportedEncodingException e) {
-			MobileCore.log(LoggingMode.DEBUG, LOG_TAG, String.format("Failed to encode urlVariable string: %s", e));
+			Log.debug(LOG_TAG, LOG_SOURCE, String.format("Failed to encode urlVariable string: %s", e));
 		}
 		return urlFragment.toString();
 	}

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/Utils.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/Utils.java
@@ -13,8 +13,7 @@ package com.adobe.marketing.mobile.edge.identity;
 
 import static com.adobe.marketing.mobile.edge.identity.IdentityConstants.LOG_TAG;
 
-import com.adobe.marketing.mobile.LoggingMode;
-import com.adobe.marketing.mobile.MobileCore;
+import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.util.JSONUtils;
 import java.util.ArrayList;
 import java.util.List;
@@ -23,6 +22,8 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 class Utils {
+
+	private static final String LOG_SOURCE = "Utils";
 
 	private Utils() {}
 
@@ -68,12 +69,8 @@ class Utils {
 			// Edge Network.
 			// TODO: Add/verify tests to check side effects of retaining nulls in the resulting Map
 			return JSONUtils.toMap(new JSONObject(map));
-		} catch (final JSONException | NullPointerException e) {
-			MobileCore.log(
-				LoggingMode.DEBUG,
-				LOG_TAG,
-				"Utils(deepCopy) - Unable to deep copy map, json string invalid."
-			);
+		} catch (final JSONException e) {
+			Log.debug(LOG_TAG, LOG_SOURCE, "Unable to deep copy map, json string invalid.");
 		}
 
 		return null;

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/Utils.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/Utils.java
@@ -69,8 +69,8 @@ class Utils {
 			// Edge Network.
 			// TODO: Add/verify tests to check side effects of retaining nulls in the resulting Map
 			return JSONUtils.toMap(new JSONObject(map));
-		} catch (final JSONException e) {
-			Log.debug(LOG_TAG, LOG_SOURCE, "Unable to deep copy map, json string invalid.");
+		} catch (final JSONException | NullPointerException e) {
+			Log.debug(LOG_TAG, LOG_SOURCE, "Unable to deep copy map, json string is invalid.");
 		}
 
 		return null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Core 2.0 now provides a Log service and a DataStoreService. Use these to replace existing logging and storage management logic.
```
- Replace MobileCore.log with Log.* in non-test classes
- Rename IdentityStorageService to IdentityStorageManager
- Make IdentityStorageService non static and inject dependency from EdgeIdentityExtension
- Fix a mistake in Identity Direct name
```

## Related Issue
[MOB-17069](https://jira.corp.adobe.com/browse/MOB-17069)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Core 2.0 now provides a Log service and a DataStoreService. Use these to replace existing logging and storage management logic.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Verified via Test app.
- Test changes will be made as a follow up PR
## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
