### PR TITLE
Use Constants from Core and add friendly name

### DIFF
--- a/code/edgeidentity/src/androidTest/java/com/adobe/marketing/mobile/edge/identity/IdentityAdIdTest.java
+++ b/code/edgeidentity/src/androidTest/java/com/adobe/marketing/mobile/edge/identity/IdentityAdIdTest.java
@@ -18,6 +18,8 @@ import static org.junit.Assert.assertEquals;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.adobe.marketing.mobile.Event;
+import com.adobe.marketing.mobile.EventSource;
+import com.adobe.marketing.mobile.EventType;
 import com.adobe.marketing.mobile.MobileCore;
 import com.adobe.marketing.mobile.edge.identity.util.MonitorExtension;
 import com.adobe.marketing.mobile.edge.identity.util.TestPersistenceHelper;
@@ -316,7 +318,7 @@ public class IdentityAdIdTest {
 	 * APIs are properly dispatched. Verifies:
 	 * 1. Event type and source
 	 * 2. Event data/properties as required for proper ad ID functionality
-	 * @param isGenericIdentityEventAdIdEvent true if the expected {@link com.adobe.marketing.mobile.edge.identity.IdentityConstants.EventType#GENERIC_IDENTITY}
+	 * @param isGenericIdentityEventAdIdEvent true if the expected {@link EventType#GENERIC_IDENTITY}
 	 *                                           event should be an ad ID event, false otherwise
 	 * @param expectedConsentValue the expected consent value in the format {@link IdentityConstants.XDMKeys.Consent#YES}
 	 *                                or {@link IdentityConstants.XDMKeys.Consent#NO}; however, if consent event should not be dispatched, use null
@@ -326,18 +328,15 @@ public class IdentityAdIdTest {
 		throws Exception {
 		// Check the event type and source
 		List<Event> dispatchedGenericIdentityEvents = getDispatchedEventsWith(
-			IdentityConstants.EventType.GENERIC_IDENTITY,
-			IdentityConstants.EventSource.REQUEST_CONTENT
+			EventType.GENERIC_IDENTITY,
+			EventSource.REQUEST_CONTENT
 		);
 		// Verify Generic Identity event
 		assertEquals(1, dispatchedGenericIdentityEvents.size());
 		Event genericIdentityEvent = dispatchedGenericIdentityEvents.get(0);
 		assertEquals(isGenericIdentityEventAdIdEvent, EventUtils.isAdIdEvent(genericIdentityEvent));
 		// Verify Edge Consent event
-		List<Event> dispatchedConsentEvents = getDispatchedEventsWith(
-			IdentityConstants.EventType.EDGE_CONSENT,
-			IdentityConstants.EventSource.UPDATE_CONSENT
-		);
+		List<Event> dispatchedConsentEvents = getDispatchedEventsWith(EventType.CONSENT, EventSource.UPDATE_CONSENT);
 		assertEquals(StringUtils.isNullOrEmpty(expectedConsentValue) ? 0 : 1, dispatchedConsentEvents.size());
 		if (!StringUtils.isNullOrEmpty(expectedConsentValue)) {
 			Map<String, String> consentDataMap = flattenMap(dispatchedConsentEvents.get(0).getEventData());
@@ -372,8 +371,8 @@ public class IdentityAdIdTest {
 	}
 
 	/**
-	 * Dispatches an event using the MobileCore dispatchEvent API. Event has type {@link com.adobe.marketing.mobile.edge.identity.IdentityConstants.EventType#GENERIC_IDENTITY}
-	 * and source {@link com.adobe.marketing.mobile.edge.identity.IdentityConstants.EventSource#REQUEST_CONTENT}.
+	 * Dispatches an event using the MobileCore dispatchEvent API. Event has type {@link EventType#GENERIC_IDENTITY}
+	 * and source {@link EventSource#REQUEST_CONTENT}.
 	 * This is the combination of event type and source that the ad ID listener will capture, and this
 	 * method helps set up test cases that verify the ad ID is not modified if the advertisingIdentifier
 	 * property is not present in the correct format
@@ -381,8 +380,8 @@ public class IdentityAdIdTest {
 	private void dispatchGenericIdentityNonAdIdEvent() {
 		Event genericIdentityNonAdIdEvent = new Event.Builder(
 			"Test event",
-			IdentityConstants.EventType.GENERIC_IDENTITY,
-			IdentityConstants.EventSource.REQUEST_CONTENT
+			EventType.GENERIC_IDENTITY,
+			EventSource.REQUEST_CONTENT
 		)
 			.setEventData(
 				new HashMap<String, Object>() {

--- a/code/edgeidentity/src/androidTest/java/com/adobe/marketing/mobile/edge/identity/IdentityPublicAPITest.java
+++ b/code/edgeidentity/src/androidTest/java/com/adobe/marketing/mobile/edge/identity/IdentityPublicAPITest.java
@@ -17,6 +17,8 @@ import static org.junit.Assert.*;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.adobe.marketing.mobile.Event;
+import com.adobe.marketing.mobile.EventSource;
+import com.adobe.marketing.mobile.EventType;
 import com.adobe.marketing.mobile.edge.identity.util.IdentityTestConstants;
 import com.adobe.marketing.mobile.edge.identity.util.MonitorExtension;
 import com.adobe.marketing.mobile.edge.identity.util.TestPersistenceHelper;
@@ -112,10 +114,7 @@ public class IdentityPublicAPITest {
 		waitForThreads(2000);
 
 		// verify no shares state change event dispatched
-		List<Event> dispatchedEvents = getDispatchedEventsWith(
-			IdentityConstants.EventType.HUB,
-			IdentityConstants.EventSource.SHARED_STATE
-		);
+		List<Event> dispatchedEvents = getDispatchedEventsWith(EventType.HUB, EventSource.SHARED_STATE);
 		assertEquals(0, dispatchedEvents.size());
 
 		// verify xdm shared state is not disturbed
@@ -131,10 +130,7 @@ public class IdentityPublicAPITest {
 		waitForThreads(2000);
 
 		// verify no shares state change event dispatched
-		List<Event> dispatchedEvents = getDispatchedEventsWith(
-			IdentityConstants.EventType.HUB,
-			IdentityConstants.EventSource.SHARED_STATE
-		);
+		List<Event> dispatchedEvents = getDispatchedEventsWith(EventType.HUB, EventSource.SHARED_STATE);
 		assertEquals(0, dispatchedEvents.size());
 
 		// verify xdm shared state is not disturbed

--- a/code/edgeidentity/src/androidTest/java/com/adobe/marketing/mobile/edge/identity/IdentityResetHandlingTest.java
+++ b/code/edgeidentity/src/androidTest/java/com/adobe/marketing/mobile/edge/identity/IdentityResetHandlingTest.java
@@ -16,6 +16,8 @@ import static com.adobe.marketing.mobile.edge.identity.util.TestHelper.*;
 import static org.junit.Assert.*;
 
 import com.adobe.marketing.mobile.Event;
+import com.adobe.marketing.mobile.EventSource;
+import com.adobe.marketing.mobile.EventType;
 import com.adobe.marketing.mobile.MobileCore;
 import com.adobe.marketing.mobile.edge.identity.util.MonitorExtension;
 import com.adobe.marketing.mobile.edge.identity.util.TestPersistenceHelper;
@@ -67,10 +69,7 @@ public class IdentityResetHandlingTest {
 		assertNotEquals(beforeResetECID, newECID);
 
 		// verify edge reset complete event dispatched
-		List<Event> resetCompleteEvent = getDispatchedEventsWith(
-			IdentityConstants.EventType.EDGE_IDENTITY,
-			IdentityConstants.EventSource.RESET_COMPLETE
-		);
+		List<Event> resetCompleteEvent = getDispatchedEventsWith(EventType.EDGE_IDENTITY, EventSource.RESET_COMPLETE);
 		assertEquals(1, resetCompleteEvent.size());
 
 		// verify shared state is updated

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/Identity.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/Identity.java
@@ -17,6 +17,8 @@ import com.adobe.marketing.mobile.AdobeCallback;
 import com.adobe.marketing.mobile.AdobeCallbackWithError;
 import com.adobe.marketing.mobile.AdobeError;
 import com.adobe.marketing.mobile.Event;
+import com.adobe.marketing.mobile.EventSource;
+import com.adobe.marketing.mobile.EventType;
 import com.adobe.marketing.mobile.Extension;
 import com.adobe.marketing.mobile.ExtensionError;
 import com.adobe.marketing.mobile.ExtensionErrorCallback;
@@ -86,8 +88,8 @@ public class Identity {
 
 		final Event event = new Event.Builder(
 			IdentityConstants.EventNames.IDENTITY_REQUEST_IDENTITY_ECID,
-			IdentityConstants.EventType.EDGE_IDENTITY,
-			IdentityConstants.EventSource.REQUEST_IDENTITY
+			EventType.EDGE_IDENTITY,
+			EventSource.REQUEST_IDENTITY
 		)
 			.build();
 
@@ -169,8 +171,8 @@ public class Identity {
 
 		final Event event = new Event.Builder(
 			IdentityConstants.EventNames.IDENTITY_REQUEST_URL_VARIABLES,
-			IdentityConstants.EventType.EDGE_IDENTITY,
-			IdentityConstants.EventSource.REQUEST_IDENTITY
+			EventType.EDGE_IDENTITY,
+			EventSource.REQUEST_IDENTITY
 		)
 			.setEventData(
 				new HashMap<String, Object>() {
@@ -237,8 +239,8 @@ public class Identity {
 
 		final Event updateIdentitiesEvent = new Event.Builder(
 			IdentityConstants.EventNames.UPDATE_IDENTITIES,
-			IdentityConstants.EventType.EDGE_IDENTITY,
-			IdentityConstants.EventSource.UPDATE_IDENTITY
+			EventType.EDGE_IDENTITY,
+			EventSource.UPDATE_IDENTITY
 		)
 			.setEventData(identityMap.asXDMMap(false))
 			.build();
@@ -269,8 +271,8 @@ public class Identity {
 
 		final Event removeIdentitiesEvent = new Event.Builder(
 			IdentityConstants.EventNames.REMOVE_IDENTITIES,
-			IdentityConstants.EventType.EDGE_IDENTITY,
-			IdentityConstants.EventSource.REMOVE_IDENTITY
+			EventType.EDGE_IDENTITY,
+			EventSource.REMOVE_IDENTITY
 		)
 			.setEventData(identityMap.asXDMMap(false))
 			.build();
@@ -296,8 +298,8 @@ public class Identity {
 
 		final Event event = new Event.Builder(
 			IdentityConstants.EventNames.REQUEST_IDENTITIES,
-			IdentityConstants.EventType.EDGE_IDENTITY,
-			IdentityConstants.EventSource.REQUEST_IDENTITY
+			EventType.EDGE_IDENTITY,
+			EventSource.REQUEST_IDENTITY
 		)
 			.build();
 

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityConstants.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityConstants.java
@@ -15,6 +15,7 @@ final class IdentityConstants {
 
 	static final String LOG_TAG = "EdgeIdentity";
 	static final String EXTENSION_NAME = "com.adobe.edge.identity";
+	static final String EXTENSION_FRIENDLY_NAME = "Edge Identity";
 	static final String EXTENSION_VERSION = "2.0.0";
 
 	static final class Default {
@@ -22,32 +23,6 @@ final class IdentityConstants {
 		static final String ZERO_ADVERTISING_ID = "00000000-0000-0000-0000-000000000000";
 
 		private Default() {}
-	}
-
-	static final class EventSource {
-
-		static final String REMOVE_IDENTITY = "com.adobe.eventSource.removeIdentity";
-		static final String REQUEST_CONTENT = "com.adobe.eventSource.requestContent";
-		static final String REQUEST_IDENTITY = "com.adobe.eventSource.requestIdentity";
-		static final String REQUEST_RESET = "com.adobe.eventSource.requestReset";
-		static final String RESET_COMPLETE = "com.adobe.eventSource.resetComplete";
-		static final String RESPONSE_IDENTITY = "com.adobe.eventSource.responseIdentity";
-		static final String SHARED_STATE = "com.adobe.eventSource.sharedState";
-		static final String UPDATE_CONSENT = "com.adobe.eventSource.updateConsent";
-		static final String UPDATE_IDENTITY = "com.adobe.eventSource.updateIdentity";
-
-		private EventSource() {}
-	}
-
-	static final class EventType {
-
-		static final String EDGE_CONSENT = "com.adobe.eventType.edgeConsent";
-		static final String EDGE_IDENTITY = "com.adobe.eventType.edgeIdentity";
-		static final String GENERIC_IDENTITY = "com.adobe.eventType.generic.identity";
-		static final String HUB = "com.adobe.eventType.hub";
-		static final String IDENTITY = "com.adobe.eventType.identity";
-
-		private EventType() {}
 	}
 
 	static final class EventNames {

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityExtension.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityExtension.java
@@ -16,6 +16,8 @@ import static com.adobe.marketing.mobile.edge.identity.IdentityConstants.LOG_TAG
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 import com.adobe.marketing.mobile.Event;
+import com.adobe.marketing.mobile.EventSource;
+import com.adobe.marketing.mobile.EventType;
 import com.adobe.marketing.mobile.Extension;
 import com.adobe.marketing.mobile.ExtensionApi;
 import com.adobe.marketing.mobile.SharedStateResolution;
@@ -72,6 +74,11 @@ class IdentityExtension extends Extension {
 	}
 
 	@Override
+	protected String getFriendlyName() {
+		return IdentityConstants.EXTENSION_FRIENDLY_NAME;
+	}
+
+	@Override
 	protected String getVersion() {
 		return IdentityConstants.EXTENSION_VERSION;
 	}
@@ -82,13 +89,13 @@ class IdentityExtension extends Extension {
 	 * <p>
 	 * The following listeners are registered during this extension's registration.
 	 * <ul>
-	 *     <li> EventType {@link IdentityConstants.EventType#GENERIC_IDENTITY} and EventSource {@link IdentityConstants.EventSource#REQUEST_CONTENT}</li>
-	 *     <li> EventType {@link IdentityConstants.EventType#EDGE_IDENTITY} and EventSource {@link IdentityConstants.EventSource#REQUEST_IDENTITY}</li>
-	 *     <li> EventType {@link IdentityConstants.EventType#EDGE_IDENTITY} and EventSource {@link IdentityConstants.EventSource#UPDATE_IDENTITY}</li>
-	 *     <li> EventType {@link IdentityConstants.EventType#EDGE_IDENTITY} and EventSource {@link IdentityConstants.EventSource#REMOVE_IDENTITY}</li>
-	 *     <li> EventType {@link IdentityConstants.EventType#EDGE_IDENTITY} and EventSource {@link IdentityConstants.EventSource#REQUEST_CONTENT}</li>
-	 *     <li> EventType {@link IdentityConstants.EventType#GENERIC_IDENTITY} and EventSource {@link IdentityConstants.EventSource#REQUEST_RESET}</li>
-	 *     <li> EventType {@link IdentityConstants.EventType#HUB} and EventSource {@link IdentityConstants.EventSource#SHARED_STATE}</li>
+	 *     <li> EventType {@link EventType#GENERIC_IDENTITY} and EventSource {@link EventSource#REQUEST_CONTENT}</li>
+	 *     <li> EventType {@link EventType#EDGE_IDENTITY} and EventSource {@link EventSource#REQUEST_IDENTITY}</li>
+	 *     <li> EventType {@link EventType#EDGE_IDENTITY} and EventSource {@link EventSource#UPDATE_IDENTITY}</li>
+	 *     <li> EventType {@link EventType#EDGE_IDENTITY} and EventSource {@link EventSource#REMOVE_IDENTITY}</li>
+	 *     <li> EventType {@link EventType#EDGE_IDENTITY} and EventSource {@link EventSource#REQUEST_CONTENT}</li>
+	 *     <li> EventType {@link EventType#GENERIC_IDENTITY} and EventSource {@link EventSource#REQUEST_RESET}</li>
+	 *     <li> EventType {@link EventType#HUB} and EventSource {@link EventSource#SHARED_STATE}</li>
 	 * </ul>
 	 * </p>
 	 */
@@ -98,48 +105,22 @@ class IdentityExtension extends Extension {
 
 		// GENERIC_IDENTITY event listeners
 		getApi()
-			.registerEventListener(
-				IdentityConstants.EventType.GENERIC_IDENTITY,
-				IdentityConstants.EventSource.REQUEST_CONTENT,
-				this::handleRequestContent
-			);
+			.registerEventListener(EventType.GENERIC_IDENTITY, EventSource.REQUEST_CONTENT, this::handleRequestContent);
 
-		getApi()
-			.registerEventListener(
-				IdentityConstants.EventType.GENERIC_IDENTITY,
-				IdentityConstants.EventSource.REQUEST_RESET,
-				this::handleRequestReset
-			);
+		getApi().registerEventListener(EventType.GENERIC_IDENTITY, EventSource.REQUEST_RESET, this::handleRequestReset);
 
 		// EDGE_IDENTITY event listeners
 		getApi()
-			.registerEventListener(
-				IdentityConstants.EventType.EDGE_IDENTITY,
-				IdentityConstants.EventSource.REQUEST_IDENTITY,
-				this::handleRequestIdentity
-			);
+			.registerEventListener(EventType.EDGE_IDENTITY, EventSource.REQUEST_IDENTITY, this::handleRequestIdentity);
 
 		getApi()
-			.registerEventListener(
-				IdentityConstants.EventType.EDGE_IDENTITY,
-				IdentityConstants.EventSource.UPDATE_IDENTITY,
-				this::handleUpdateIdentities
-			);
+			.registerEventListener(EventType.EDGE_IDENTITY, EventSource.UPDATE_IDENTITY, this::handleUpdateIdentities);
 
 		getApi()
-			.registerEventListener(
-				IdentityConstants.EventType.EDGE_IDENTITY,
-				IdentityConstants.EventSource.REMOVE_IDENTITY,
-				this::handleRemoveIdentity
-			);
+			.registerEventListener(EventType.EDGE_IDENTITY, EventSource.REMOVE_IDENTITY, this::handleRemoveIdentity);
 
 		// HUB shared state event listener
-		getApi()
-			.registerEventListener(
-				IdentityConstants.EventType.HUB,
-				IdentityConstants.EventSource.SHARED_STATE,
-				this::handleIdentityDirectECIDUpdate
-			);
+		getApi().registerEventListener(EventType.HUB, EventSource.SHARED_STATE, this::handleIdentityDirectECIDUpdate);
 	}
 
 	@Override
@@ -243,8 +224,8 @@ class IdentityExtension extends Extension {
 	) {
 		Event responseEvent = new Event.Builder(
 			IdentityConstants.EventNames.IDENTITY_RESPONSE_URL_VARIABLES,
-			IdentityConstants.EventType.EDGE_IDENTITY,
-			IdentityConstants.EventSource.RESPONSE_IDENTITY
+			EventType.EDGE_IDENTITY,
+			EventSource.RESPONSE_IDENTITY
 		)
 			.setEventData(
 				new HashMap<String, Object>() {
@@ -328,8 +309,8 @@ class IdentityExtension extends Extension {
 		final Map<String, Object> xdmData = state.getIdentityProperties().toXDMData(false);
 		final Event responseEvent = new Event.Builder(
 			IdentityConstants.EventNames.IDENTITY_RESPONSE_CONTENT_ONE_TIME,
-			IdentityConstants.EventType.EDGE_IDENTITY,
-			IdentityConstants.EventSource.RESPONSE_IDENTITY
+			EventType.EDGE_IDENTITY,
+			EventSource.RESPONSE_IDENTITY
 		)
 			.setEventData(xdmData)
 			.inResponseToEvent(event)
@@ -350,8 +331,8 @@ class IdentityExtension extends Extension {
 		// dispatch reset complete event
 		final Event responseEvent = new Event.Builder(
 			IdentityConstants.EventNames.RESET_IDENTITIES_COMPLETE,
-			IdentityConstants.EventType.EDGE_IDENTITY,
-			IdentityConstants.EventSource.RESET_COMPLETE
+			EventType.EDGE_IDENTITY,
+			EventSource.RESET_COMPLETE
 		)
 			.inResponseToEvent(event)
 			.build();

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityState.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityState.java
@@ -16,6 +16,8 @@ import static com.adobe.marketing.mobile.edge.identity.IdentityConstants.LOG_TAG
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 import com.adobe.marketing.mobile.Event;
+import com.adobe.marketing.mobile.EventSource;
+import com.adobe.marketing.mobile.EventType;
 import com.adobe.marketing.mobile.MobileCore;
 import com.adobe.marketing.mobile.SharedStateResult;
 import com.adobe.marketing.mobile.SharedStateStatus;
@@ -326,8 +328,8 @@ class IdentityState {
 
 		final Event consentEvent = new Event.Builder(
 			IdentityConstants.EventNames.CONSENT_UPDATE_REQUEST_AD_ID,
-			IdentityConstants.EventType.EDGE_CONSENT,
-			IdentityConstants.EventSource.UPDATE_CONSENT
+			EventType.CONSENT,
+			EventSource.UPDATE_CONSENT
 		)
 			.setEventData(consentData)
 			.build();

--- a/code/edgeidentity/src/test/java/com/adobe/marketing/mobile/edge/identity/EventUtilsTests.java
+++ b/code/edgeidentity/src/test/java/com/adobe/marketing/mobile/edge/identity/EventUtilsTests.java
@@ -17,6 +17,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.adobe.marketing.mobile.Event;
+import com.adobe.marketing.mobile.EventSource;
+import com.adobe.marketing.mobile.EventType;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -37,8 +39,8 @@ public class EventUtilsTests {
 	public void test_isRequestIdentityEventForGetUrlVariable_eventContainsUrlVariablesKey_validBooleanValue_returnsSetBooleanValue() {
 		Event event = new Event.Builder(
 			IdentityConstants.EventNames.IDENTITY_REQUEST_URL_VARIABLES,
-			IdentityConstants.EventType.EDGE_IDENTITY,
-			IdentityConstants.EventSource.REQUEST_IDENTITY
+			EventType.EDGE_IDENTITY,
+			EventSource.REQUEST_IDENTITY
 		)
 			.setEventData(
 				new HashMap<String, Object>() {
@@ -55,8 +57,8 @@ public class EventUtilsTests {
 		event =
 			new Event.Builder(
 				IdentityConstants.EventNames.IDENTITY_REQUEST_URL_VARIABLES,
-				IdentityConstants.EventType.EDGE_IDENTITY,
-				IdentityConstants.EventSource.REQUEST_IDENTITY
+				EventType.EDGE_IDENTITY,
+				EventSource.REQUEST_IDENTITY
 			)
 				.setEventData(
 					new HashMap<String, Object>() {
@@ -75,8 +77,8 @@ public class EventUtilsTests {
 		// eventType is not edgeIdentity and eventSource is not requestIdentity
 		Event event = new Event.Builder(
 			IdentityConstants.EventNames.IDENTITY_REQUEST_URL_VARIABLES,
-			IdentityConstants.EventType.IDENTITY,
-			IdentityConstants.EventSource.REQUEST_RESET
+			EventType.IDENTITY,
+			EventSource.REQUEST_RESET
 		)
 			.setEventData(
 				new HashMap<String, Object>() {
@@ -93,8 +95,8 @@ public class EventUtilsTests {
 		event =
 			new Event.Builder(
 				IdentityConstants.EventNames.IDENTITY_REQUEST_URL_VARIABLES,
-				IdentityConstants.EventType.IDENTITY,
-				IdentityConstants.EventSource.REQUEST_IDENTITY
+				EventType.IDENTITY,
+				EventSource.REQUEST_IDENTITY
 			)
 				.setEventData(
 					new HashMap<String, Object>() {
@@ -112,8 +114,8 @@ public class EventUtilsTests {
 	public void test_RequestIdentityEventForGetUrlVariable_eventContainsUrlVariablesKey_invalidValue_returnsFalse() {
 		Event event = new Event.Builder(
 			IdentityConstants.EventNames.IDENTITY_REQUEST_URL_VARIABLES,
-			IdentityConstants.EventType.EDGE_IDENTITY,
-			IdentityConstants.EventSource.REQUEST_IDENTITY
+			EventType.EDGE_IDENTITY,
+			EventSource.REQUEST_IDENTITY
 		)
 			.setEventData(
 				new HashMap<String, Object>() {
@@ -130,8 +132,8 @@ public class EventUtilsTests {
 		event =
 			new Event.Builder(
 				IdentityConstants.EventNames.IDENTITY_REQUEST_URL_VARIABLES,
-				IdentityConstants.EventType.EDGE_IDENTITY,
-				IdentityConstants.EventSource.REQUEST_IDENTITY
+				EventType.EDGE_IDENTITY,
+				EventSource.REQUEST_IDENTITY
 			)
 				.setEventData(
 					new HashMap<String, Object>() {
@@ -299,8 +301,8 @@ public class EventUtilsTests {
 	public void test_isSharedStateUpdateFor_stateOwnerIsNull() {
 		final Event event = new Event.Builder(
 			"Shared state event",
-			IdentityConstants.EventType.GENERIC_IDENTITY,
-			IdentityConstants.EventSource.REQUEST_IDENTITY
+			EventType.GENERIC_IDENTITY,
+			EventSource.REQUEST_IDENTITY
 		)
 			.setEventData(Collections.EMPTY_MAP)
 			.build();
@@ -317,21 +319,21 @@ public class EventUtilsTests {
 	public void test_isSharedStateUpdateFor_stateOwnerValueIsNull() {
 		final Event event = new Event.Builder(
 			"Shared state event",
-			IdentityConstants.EventType.GENERIC_IDENTITY,
-			IdentityConstants.EventSource.REQUEST_IDENTITY
+			EventType.GENERIC_IDENTITY,
+			EventSource.REQUEST_IDENTITY
 		)
 			.setEventData(Collections.singletonMap(IdentityConstants.EventDataKeys.STATE_OWNER, null))
 			.build();
 
-		assertFalse(EventUtils.isSharedStateUpdateFor(IdentityConstants.EventType.GENERIC_IDENTITY, event));
+		assertFalse(EventUtils.isSharedStateUpdateFor(EventType.GENERIC_IDENTITY, event));
 	}
 
 	@Test
 	public void test_isSharedStateUpdateFor_stateOwnerValueIsEmpty() {
 		final Event event = new Event.Builder(
 			"Shared state event",
-			IdentityConstants.EventType.GENERIC_IDENTITY,
-			IdentityConstants.EventSource.REQUEST_IDENTITY
+			EventType.GENERIC_IDENTITY,
+			EventSource.REQUEST_IDENTITY
 		)
 			.setEventData(Collections.singletonMap(IdentityConstants.EventDataKeys.STATE_OWNER, ""))
 			.build();
@@ -343,8 +345,8 @@ public class EventUtilsTests {
 	public void test_isSharedStateUpdateFor_stateOwnerValueExists() {
 		final Event event = new Event.Builder(
 			"Shared state event",
-			IdentityConstants.EventType.GENERIC_IDENTITY,
-			IdentityConstants.EventSource.REQUEST_IDENTITY
+			EventType.GENERIC_IDENTITY,
+			EventSource.REQUEST_IDENTITY
 		)
 			.setEventData(
 				Collections.singletonMap(IdentityConstants.EventDataKeys.STATE_OWNER, "com.adobe.module.configuration")
@@ -389,11 +391,7 @@ public class EventUtilsTests {
 	 * @return {@link Event} with the given event data set
 	 */
 	private Event createGenericIdentityEvent(final HashMap<String, Object> data) {
-		return new Event.Builder(
-			"Test event",
-			IdentityConstants.EventType.GENERIC_IDENTITY,
-			IdentityConstants.EventSource.REQUEST_IDENTITY
-		)
+		return new Event.Builder("Test event", EventType.GENERIC_IDENTITY, EventSource.REQUEST_IDENTITY)
 			.setEventData(data)
 			.build();
 	}

--- a/code/edgeidentity/src/test/java/com/adobe/marketing/mobile/edge/identity/IdentityExtensionTests.java
+++ b/code/edgeidentity/src/test/java/com/adobe/marketing/mobile/edge/identity/IdentityExtensionTests.java
@@ -27,6 +27,8 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.adobe.marketing.mobile.Event;
+import com.adobe.marketing.mobile.EventSource;
+import com.adobe.marketing.mobile.EventType;
 import com.adobe.marketing.mobile.ExtensionApi;
 import com.adobe.marketing.mobile.SharedStateResolution;
 import com.adobe.marketing.mobile.SharedStateResult;
@@ -68,41 +70,16 @@ public class IdentityExtensionTests {
 
 		// verify
 		verify(mockExtensionApi)
-			.registerEventListener(
-				eq(IdentityConstants.EventType.GENERIC_IDENTITY),
-				eq(IdentityConstants.EventSource.REQUEST_CONTENT),
-				any()
-			);
+			.registerEventListener(eq(EventType.GENERIC_IDENTITY), eq(EventSource.REQUEST_CONTENT), any());
 		verify(mockExtensionApi)
-			.registerEventListener(
-				eq(IdentityConstants.EventType.GENERIC_IDENTITY),
-				eq(IdentityConstants.EventSource.REQUEST_RESET),
-				any()
-			);
+			.registerEventListener(eq(EventType.GENERIC_IDENTITY), eq(EventSource.REQUEST_RESET), any());
 		verify(mockExtensionApi)
-			.registerEventListener(
-				eq(IdentityConstants.EventType.EDGE_IDENTITY),
-				eq(IdentityConstants.EventSource.REQUEST_IDENTITY),
-				any()
-			);
+			.registerEventListener(eq(EventType.EDGE_IDENTITY), eq(EventSource.REQUEST_IDENTITY), any());
 		verify(mockExtensionApi)
-			.registerEventListener(
-				eq(IdentityConstants.EventType.EDGE_IDENTITY),
-				eq(IdentityConstants.EventSource.UPDATE_IDENTITY),
-				any()
-			);
+			.registerEventListener(eq(EventType.EDGE_IDENTITY), eq(EventSource.UPDATE_IDENTITY), any());
 		verify(mockExtensionApi)
-			.registerEventListener(
-				eq(IdentityConstants.EventType.EDGE_IDENTITY),
-				eq(IdentityConstants.EventSource.REMOVE_IDENTITY),
-				any()
-			);
-		verify(mockExtensionApi)
-			.registerEventListener(
-				eq(IdentityConstants.EventType.HUB),
-				eq(IdentityConstants.EventSource.SHARED_STATE),
-				any()
-			);
+			.registerEventListener(eq(EventType.EDGE_IDENTITY), eq(EventSource.REMOVE_IDENTITY), any());
+		verify(mockExtensionApi).registerEventListener(eq(EventType.HUB), eq(EventSource.SHARED_STATE), any());
 
 		verifyNoMoreInteractions(mockExtensionApi);
 	}
@@ -116,6 +93,21 @@ public class IdentityExtensionTests {
 		extension = new IdentityExtension(mockExtensionApi);
 		final String moduleName = extension.getName();
 		assertEquals("getName should return the correct module name", IdentityConstants.EXTENSION_NAME, moduleName);
+	}
+
+	// ========================================================================================
+	// getFriendlyName
+	// ========================================================================================
+	@Test
+	public void test_getFriendlyName() {
+		extension = new IdentityExtension(mockExtensionApi);
+
+		final String extensionFriendlyName = extension.getFriendlyName();
+		assertEquals(
+			"getFriendlyName should return the correct friendly name",
+			IdentityConstants.EXTENSION_FRIENDLY_NAME,
+			extensionFriendlyName
+		);
 	}
 
 	// ========================================================================================
@@ -150,11 +142,7 @@ public class IdentityExtensionTests {
 	public void test_readyForEvent_GetUrlVariablesRequestButConfigurationStateUnavailable() {
 		// setup
 		when(mockIdentityState.bootupIfReady(any())).thenReturn(true);
-		Event event = new Event.Builder(
-			"Test event",
-			IdentityConstants.EventType.EDGE_IDENTITY,
-			IdentityConstants.EventSource.REQUEST_IDENTITY
-		)
+		Event event = new Event.Builder("Test event", EventType.EDGE_IDENTITY, EventSource.REQUEST_IDENTITY)
 			.setEventData(
 				new HashMap<String, Object>() {
 					{
@@ -183,11 +171,7 @@ public class IdentityExtensionTests {
 	public void test_readyForEvent_GetUrlVariablesRequest_ConfigurationStatePending() {
 		// setup
 		when(mockIdentityState.bootupIfReady(any())).thenReturn(true);
-		Event event = new Event.Builder(
-			"Test event",
-			IdentityConstants.EventType.EDGE_IDENTITY,
-			IdentityConstants.EventSource.REQUEST_IDENTITY
-		)
+		Event event = new Event.Builder("Test event", EventType.EDGE_IDENTITY, EventSource.REQUEST_IDENTITY)
 			.setEventData(
 				new HashMap<String, Object>() {
 					{
@@ -216,11 +200,7 @@ public class IdentityExtensionTests {
 	public void test_readyForEvent_GetUrlVariablesRequest_ConfigurationStateSet() {
 		// setup
 		when(mockIdentityState.bootupIfReady(any())).thenReturn(true);
-		Event event = new Event.Builder(
-			"Test event",
-			IdentityConstants.EventType.EDGE_IDENTITY,
-			IdentityConstants.EventSource.REQUEST_IDENTITY
-		)
+		Event event = new Event.Builder("Test event", EventType.EDGE_IDENTITY, EventSource.REQUEST_IDENTITY)
 			.setEventData(
 				new HashMap<String, Object>() {
 					{
@@ -268,12 +248,7 @@ public class IdentityExtensionTests {
 
 		extension = new IdentityExtension(mockExtensionApi, mockIdentityState);
 
-		Event event = new Event.Builder(
-			"Test event",
-			IdentityConstants.EventType.EDGE_IDENTITY,
-			IdentityConstants.EventSource.REQUEST_IDENTITY
-		)
-			.build();
+		Event event = new Event.Builder("Test event", EventType.EDGE_IDENTITY, EventSource.REQUEST_IDENTITY).build();
 		final ArgumentCaptor<Event> responseEventCaptor = ArgumentCaptor.forClass(Event.class);
 
 		// test
@@ -302,8 +277,8 @@ public class IdentityExtensionTests {
 	public void test_handleIdentityDirectECIDUpdate_notAnIdentityDirectStateUpdate() {
 		final Event event = new Event.Builder(
 			"Not an IdentityDirect State event",
-			IdentityConstants.EventType.HUB,
-			IdentityConstants.EventSource.SHARED_STATE
+			EventType.HUB,
+			EventSource.SHARED_STATE
 		)
 			.setEventData(
 				new HashMap<String, Object>() {
@@ -324,11 +299,7 @@ public class IdentityExtensionTests {
 
 	@Test
 	public void test_handleIdentityDirectECIDUpdate_identityDirectStateResultIsNull() {
-		final Event event = new Event.Builder(
-			"IdentityDirect State event",
-			IdentityConstants.EventType.HUB,
-			IdentityConstants.EventSource.SHARED_STATE
-		)
+		final Event event = new Event.Builder("IdentityDirect State event", EventType.HUB, EventSource.SHARED_STATE)
 			.setEventData(
 				new HashMap<String, Object>() {
 					{
@@ -366,11 +337,7 @@ public class IdentityExtensionTests {
 
 	@Test
 	public void test_handleIdentityDirectECIDUpdate_identityDirectStateIsNull() {
-		final Event event = new Event.Builder(
-			"IdentityDirect State event",
-			IdentityConstants.EventType.HUB,
-			IdentityConstants.EventSource.SHARED_STATE
-		)
+		final Event event = new Event.Builder("IdentityDirect State event", EventType.HUB, EventSource.SHARED_STATE)
 			.setEventData(
 				new HashMap<String, Object>() {
 					{
@@ -408,11 +375,7 @@ public class IdentityExtensionTests {
 
 	@Test
 	public void test_handleIdentityDirectECIDUpdate_legacyEcidUpdateFailed() {
-		final Event event = new Event.Builder(
-			"IdentityDirect State event",
-			IdentityConstants.EventType.HUB,
-			IdentityConstants.EventSource.SHARED_STATE
-		)
+		final Event event = new Event.Builder("IdentityDirect State event", EventType.HUB, EventSource.SHARED_STATE)
 			.setEventData(
 				new HashMap<String, Object>() {
 					{
@@ -457,11 +420,7 @@ public class IdentityExtensionTests {
 
 	@Test
 	public void test_handleIdentityDirectECIDUpdate_identityDirectStateValidECID() {
-		final Event event = new Event.Builder(
-			"IdentityDirect State event",
-			IdentityConstants.EventType.HUB,
-			IdentityConstants.EventSource.SHARED_STATE
-		)
+		final Event event = new Event.Builder("IdentityDirect State event", EventType.HUB, EventSource.SHARED_STATE)
 			.setEventData(
 				new HashMap<String, Object>() {
 					{
@@ -522,11 +481,7 @@ public class IdentityExtensionTests {
 	@Test
 	public void test_handleUrlVariablesRequest_whenOrgIdAndECIDNotPresent_returnsNull() {
 		// setup
-		Event event = new Event.Builder(
-			"Test event",
-			IdentityConstants.EventType.EDGE_IDENTITY,
-			IdentityConstants.EventSource.REQUEST_IDENTITY
-		)
+		Event event = new Event.Builder("Test event", EventType.EDGE_IDENTITY, EventSource.REQUEST_IDENTITY)
 			.setEventData(
 				new HashMap<String, Object>() {
 					{
@@ -571,11 +526,7 @@ public class IdentityExtensionTests {
 	@Test
 	public void test_handleUrlVariablesRequest_whenOrgIdPresentAndECIDNotPresent_returnsNull() {
 		// setup
-		Event event = new Event.Builder(
-			"Test event",
-			IdentityConstants.EventType.EDGE_IDENTITY,
-			IdentityConstants.EventSource.REQUEST_IDENTITY
-		)
+		Event event = new Event.Builder("Test event", EventType.EDGE_IDENTITY, EventSource.REQUEST_IDENTITY)
 			.setEventData(
 				new HashMap<String, Object>() {
 					{
@@ -631,11 +582,7 @@ public class IdentityExtensionTests {
 	@Test
 	public void test_handleUrlVariablesRequest_whenOrgIdAndECIDPresent_returnsValidUrlVariables() {
 		// setup
-		Event event = new Event.Builder(
-			"Test event",
-			IdentityConstants.EventType.EDGE_IDENTITY,
-			IdentityConstants.EventSource.REQUEST_IDENTITY
-		)
+		Event event = new Event.Builder("Test event", EventType.EDGE_IDENTITY, EventSource.REQUEST_IDENTITY)
 			.setEventData(
 				new HashMap<String, Object>() {
 					{
@@ -723,8 +670,8 @@ public class IdentityExtensionTests {
 		);
 		final Event updateIdentityEvent = new Event.Builder(
 			"Update Identity Event",
-			IdentityConstants.EventType.EDGE_IDENTITY,
-			IdentityConstants.EventSource.UPDATE_IDENTITY
+			EventType.EDGE_IDENTITY,
+			EventSource.UPDATE_IDENTITY
 		)
 			.setEventData(identityXDM)
 			.build();
@@ -750,8 +697,8 @@ public class IdentityExtensionTests {
 		// test
 		final Event updateIdentityEvent = new Event.Builder(
 			"Update Identity Event",
-			IdentityConstants.EventType.EDGE_IDENTITY,
-			IdentityConstants.EventSource.UPDATE_IDENTITY
+			EventType.EDGE_IDENTITY,
+			EventSource.UPDATE_IDENTITY
 		) // no event data
 			.build();
 		extension.handleUpdateIdentities(updateIdentityEvent);
@@ -774,8 +721,8 @@ public class IdentityExtensionTests {
 		// test
 		final Event updateIdentityEvent = new Event.Builder(
 			"Update Identity Event",
-			IdentityConstants.EventType.EDGE_IDENTITY,
-			IdentityConstants.EventSource.UPDATE_IDENTITY
+			EventType.EDGE_IDENTITY,
+			EventSource.UPDATE_IDENTITY
 		)
 			.setEventData(new HashMap<>())
 			.build();
@@ -883,8 +830,8 @@ public class IdentityExtensionTests {
 		// Setup
 		final Event event = new Event.Builder(
 			"Test Ad ID event",
-			IdentityConstants.EventType.GENERIC_IDENTITY,
-			IdentityConstants.EventSource.REQUEST_CONTENT
+			EventType.GENERIC_IDENTITY,
+			EventSource.REQUEST_CONTENT
 		)
 			.setEventData(
 				new HashMap<String, Object>() {
@@ -908,8 +855,8 @@ public class IdentityExtensionTests {
 		// Setup
 		final Event event = new Event.Builder(
 			"Not an Ad ID event",
-			IdentityConstants.EventType.GENERIC_IDENTITY,
-			IdentityConstants.EventSource.REQUEST_CONTENT
+			EventType.GENERIC_IDENTITY,
+			EventSource.REQUEST_CONTENT
 		)
 			.setEventData(
 				new HashMap<String, Object>() {
@@ -939,11 +886,7 @@ public class IdentityExtensionTests {
 
 		extension = new IdentityExtension(mockExtensionApi, mockIdentityState);
 
-		Event resetEvent = new Event.Builder(
-			"Test event",
-			IdentityConstants.EventType.EDGE_IDENTITY,
-			IdentityConstants.EventSource.REQUEST_IDENTITY
-		)
+		Event resetEvent = new Event.Builder("Test event", EventType.EDGE_IDENTITY, EventSource.REQUEST_IDENTITY)
 			.build();
 
 		extension.handleRequestReset(resetEvent);

--- a/code/edgeidentity/src/test/java/com/adobe/marketing/mobile/edge/identity/IdentityStateTests.java
+++ b/code/edgeidentity/src/test/java/com/adobe/marketing/mobile/edge/identity/IdentityStateTests.java
@@ -28,6 +28,8 @@ import static org.mockito.Mockito.when;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.adobe.marketing.mobile.Event;
+import com.adobe.marketing.mobile.EventSource;
+import com.adobe.marketing.mobile.EventType;
 import com.adobe.marketing.mobile.MobileCore;
 import com.adobe.marketing.mobile.SharedStateResult;
 import com.adobe.marketing.mobile.SharedStateStatus;
@@ -788,11 +790,7 @@ public class IdentityStateTests {
 	 * @return
 	 */
 	private Event fakeGenericIdentityEvent(final String adId) {
-		return new Event.Builder(
-			"Test event",
-			IdentityConstants.EventType.GENERIC_IDENTITY,
-			IdentityConstants.EventSource.REQUEST_IDENTITY
-		)
+		return new Event.Builder("Test event", EventType.GENERIC_IDENTITY, EventSource.REQUEST_IDENTITY)
 			.setEventData(
 				new HashMap<String, Object>() {
 					{

--- a/code/edgeidentity/src/test/java/com/adobe/marketing/mobile/edge/identity/IdentityTestUtil.java
+++ b/code/edgeidentity/src/test/java/com/adobe/marketing/mobile/edge/identity/IdentityTestUtil.java
@@ -12,6 +12,8 @@
 package com.adobe.marketing.mobile.edge.identity;
 
 import com.adobe.marketing.mobile.Event;
+import com.adobe.marketing.mobile.EventSource;
+import com.adobe.marketing.mobile.EventType;
 import com.adobe.marketing.mobile.LoggingMode;
 import com.adobe.marketing.mobile.MobileCore;
 import com.adobe.marketing.mobile.util.JSONUtils;
@@ -74,11 +76,7 @@ class IdentityTestUtil {
 	 * Helper method to build remove identity request event with XDM formatted Identity map
 	 */
 	static Event buildRemoveIdentityRequest(final Map<String, Object> map) {
-		return new Event.Builder(
-			"Remove Identity Event",
-			IdentityConstants.EventType.EDGE_IDENTITY,
-			IdentityConstants.EventSource.REMOVE_IDENTITY
-		)
+		return new Event.Builder("Remove Identity Event", EventType.EDGE_IDENTITY, EventSource.REMOVE_IDENTITY)
 			.setEventData(map)
 			.build();
 	}
@@ -96,11 +94,7 @@ class IdentityTestUtil {
 	 * Helper method to build update identity request event with XDM formatted Identity map
 	 */
 	static Event buildUpdateIdentityRequest(final Map<String, Object> map) {
-		return new Event.Builder(
-			"Update Identity Event",
-			IdentityConstants.EventType.EDGE_IDENTITY,
-			IdentityConstants.EventSource.UPDATE_IDENTITY
-		)
+		return new Event.Builder("Update Identity Event", EventType.EDGE_IDENTITY, EventSource.UPDATE_IDENTITY)
 			.setEventData(map)
 			.build();
 	}

--- a/code/edgeidentity/src/test/java/com/adobe/marketing/mobile/edge/identity/IdentityTests.java
+++ b/code/edgeidentity/src/test/java/com/adobe/marketing/mobile/edge/identity/IdentityTests.java
@@ -26,6 +26,8 @@ import com.adobe.marketing.mobile.AdobeCallback;
 import com.adobe.marketing.mobile.AdobeCallbackWithError;
 import com.adobe.marketing.mobile.AdobeError;
 import com.adobe.marketing.mobile.Event;
+import com.adobe.marketing.mobile.EventSource;
+import com.adobe.marketing.mobile.EventType;
 import com.adobe.marketing.mobile.ExtensionError;
 import com.adobe.marketing.mobile.ExtensionErrorCallback;
 import com.adobe.marketing.mobile.MobileCore;
@@ -120,8 +122,8 @@ public class IdentityTests {
 			// verify the dispatched event details
 			final Event dispatchedEvent = eventCaptor.getValue();
 			assertEquals(IdentityConstants.EventNames.IDENTITY_REQUEST_IDENTITY_ECID, dispatchedEvent.getName());
-			assertEquals(IdentityConstants.EventType.EDGE_IDENTITY, dispatchedEvent.getType());
-			assertEquals(IdentityConstants.EventSource.REQUEST_IDENTITY, dispatchedEvent.getSource());
+			assertEquals(EventType.EDGE_IDENTITY, dispatchedEvent.getType());
+			assertEquals(EventSource.REQUEST_IDENTITY, dispatchedEvent.getSource());
 			assertNull(dispatchedEvent.getEventData());
 
 			// verify callback responses
@@ -382,8 +384,8 @@ public class IdentityTests {
 		// verify the dispatched event details
 		final Event dispatchedEvent = eventCaptor.getValue();
 		assertEquals(IdentityConstants.EventNames.IDENTITY_REQUEST_URL_VARIABLES, dispatchedEvent.getName());
-		assertEquals(IdentityConstants.EventType.EDGE_IDENTITY, dispatchedEvent.getType());
-		assertEquals(IdentityConstants.EventSource.REQUEST_IDENTITY, dispatchedEvent.getSource());
+		assertEquals(EventType.EDGE_IDENTITY, dispatchedEvent.getType());
+		assertEquals(EventSource.REQUEST_IDENTITY, dispatchedEvent.getSource());
 		assertTrue(dispatchedEvent.getEventData().containsKey("urlvariables"));
 		assertTrue((boolean) dispatchedEvent.getEventData().get("urlvariables"));
 
@@ -453,8 +455,8 @@ public class IdentityTests {
 
 		final Event dispatchedEvent = eventCaptor.getValue();
 		assertEquals(IdentityConstants.EventNames.IDENTITY_REQUEST_URL_VARIABLES, dispatchedEvent.getName());
-		assertEquals(IdentityConstants.EventType.EDGE_IDENTITY, dispatchedEvent.getType());
-		assertEquals(IdentityConstants.EventSource.REQUEST_IDENTITY, dispatchedEvent.getSource());
+		assertEquals(EventType.EDGE_IDENTITY, dispatchedEvent.getType());
+		assertEquals(EventSource.REQUEST_IDENTITY, dispatchedEvent.getSource());
 		assertTrue(dispatchedEvent.getEventData().containsKey("urlvariables"));
 		assertTrue((boolean) dispatchedEvent.getEventData().get("urlvariables"));
 
@@ -624,8 +626,8 @@ public class IdentityTests {
 		// verify the dispatched event details
 		Event dispatchedEvent = eventCaptor.getValue();
 		assertEquals(IdentityConstants.EventNames.UPDATE_IDENTITIES, dispatchedEvent.getName());
-		assertEquals(IdentityConstants.EventType.EDGE_IDENTITY, dispatchedEvent.getType());
-		assertEquals(IdentityConstants.EventSource.UPDATE_IDENTITY, dispatchedEvent.getSource());
+		assertEquals(EventType.EDGE_IDENTITY, dispatchedEvent.getType());
+		assertEquals(EventSource.UPDATE_IDENTITY, dispatchedEvent.getSource());
 		assertEquals(map.asXDMMap(), dispatchedEvent.getEventData());
 	}
 
@@ -678,8 +680,8 @@ public class IdentityTests {
 
 		final Event dispatchedEvent = eventCaptor.getValue();
 		assertEquals(IdentityConstants.EventNames.REMOVE_IDENTITIES, dispatchedEvent.getName());
-		assertEquals(IdentityConstants.EventType.EDGE_IDENTITY, dispatchedEvent.getType());
-		assertEquals(IdentityConstants.EventSource.REMOVE_IDENTITY, dispatchedEvent.getSource());
+		assertEquals(EventType.EDGE_IDENTITY, dispatchedEvent.getType());
+		assertEquals(EventSource.REMOVE_IDENTITY, dispatchedEvent.getSource());
 
 		final IdentityMap expectedIdentityMap = new IdentityMap();
 		expectedIdentityMap.addItem(sampleItem, "namespace");
@@ -741,8 +743,8 @@ public class IdentityTests {
 		// verify the dispatched event details
 		final Event dispatchedEvent = eventCaptor.getValue();
 		assertEquals(IdentityConstants.EventNames.REQUEST_IDENTITIES, dispatchedEvent.getName());
-		assertEquals(IdentityConstants.EventType.EDGE_IDENTITY, dispatchedEvent.getType());
-		assertEquals(IdentityConstants.EventSource.REQUEST_IDENTITY, dispatchedEvent.getSource());
+		assertEquals(EventType.EDGE_IDENTITY, dispatchedEvent.getType());
+		assertEquals(EventSource.REQUEST_IDENTITY, dispatchedEvent.getSource());
 		assertNull(dispatchedEvent.getEventData());
 
 		// verify callback responses
@@ -994,8 +996,8 @@ public class IdentityTests {
 	private Event buildIdentityResponseEvent(final Map<String, Object> eventData) {
 		return new Event.Builder(
 			IdentityConstants.EventNames.IDENTITY_REQUEST_IDENTITY_ECID,
-			IdentityConstants.EventType.EDGE_IDENTITY,
-			IdentityConstants.EventSource.RESPONSE_IDENTITY
+			EventType.EDGE_IDENTITY,
+			EventSource.RESPONSE_IDENTITY
 		)
 			.setEventData(eventData)
 			.build();
@@ -1004,8 +1006,8 @@ public class IdentityTests {
 	private Event buildUrlVariablesResponseEvent(final Map<String, Object> eventData) {
 		return new Event.Builder(
 			IdentityConstants.EventNames.IDENTITY_REQUEST_URL_VARIABLES,
-			IdentityConstants.EventType.EDGE_IDENTITY,
-			IdentityConstants.EventSource.RESPONSE_IDENTITY
+			EventType.EDGE_IDENTITY,
+			EventSource.RESPONSE_IDENTITY
 		)
 			.setEventData(eventData)
 			.build();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
EdgeIdentityExtension currently uses local constants for EventType and EventSource. These constants are now provided in  Core. Use the constants from core.

## Related Issue
N/A
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
EdgeIdentityExtension currently uses local constants for EventType and EventSource. These constants are now provided in  Core. Use the constants from core.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Unit tests
- build verification
## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
