### PR TITLE
Set pending shared state before updating Identity Map

### DIFF
--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityExtension.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityExtension.java
@@ -251,10 +251,14 @@ class IdentityExtension extends Extension {
 	 * @param event the edge update identity {@link Event}
 	 */
 	void handleUpdateIdentities(@NonNull final Event event) {
+		// Add pending shared state to avoid race condition between updating and reading identity map
+		final SharedStateResolver resolver = getApi().createPendingXDMSharedState(event);
+
 		final Map<String, Object> eventData = event.getEventData();
 
 		if (eventData == null) {
 			Log.trace(LOG_TAG, LOG_SOURCE, "Cannot update identifiers, event data is null.");
+			resolver.resolve(state.getIdentityProperties().toXDMData(false));
 			return;
 		}
 
@@ -266,11 +270,10 @@ class IdentityExtension extends Extension {
 				LOG_SOURCE,
 				"Failed to update identifiers as no identifiers were found in the event data."
 			);
+			resolver.resolve(state.getIdentityProperties().toXDMData(false));
 			return;
 		}
 
-		// Add pending shared state to avoid race condition between updating and reading identity map
-		final SharedStateResolver resolver = getApi().createPendingXDMSharedState(event);
 		state.updateCustomerIdentifiers(map);
 		resolver.resolve(state.getIdentityProperties().toXDMData(false));
 	}
@@ -281,10 +284,14 @@ class IdentityExtension extends Extension {
 	 * @param event the edge remove identity request {@link Event}
 	 */
 	void handleRemoveIdentity(@NonNull final Event event) {
+		// Add pending shared state to avoid race condition between updating and reading identity map
+		final SharedStateResolver resolver = getApi().createPendingXDMSharedState(event);
+
 		final Map<String, Object> eventData = event.getEventData();
 
 		if (eventData == null) {
 			Log.trace(LOG_TAG, LOG_SOURCE, "Cannot remove identifiers, event data is null.");
+			resolver.resolve(state.getIdentityProperties().toXDMData(false));
 			return;
 		}
 
@@ -296,11 +303,10 @@ class IdentityExtension extends Extension {
 				LOG_SOURCE,
 				"Failed to remove identifiers as no identifiers were found in the event data."
 			);
+			resolver.resolve(state.getIdentityProperties().toXDMData(false));
 			return;
 		}
 
-		// Add pending shared state to avoid race condition between updating and reading identity map
-		final SharedStateResolver resolver = getApi().createPendingXDMSharedState(event);
 		state.removeCustomerIdentifiers(map);
 		resolver.resolve(state.getIdentityProperties().toXDMData(false));
 	}
@@ -330,8 +336,10 @@ class IdentityExtension extends Extension {
 	 * @param event the identity request reset {@link Event}
 	 */
 	void handleRequestReset(@NonNull final Event event) {
+		// Add pending shared state to avoid race condition between updating and reading identity map
+		final SharedStateResolver resolver = getApi().createPendingXDMSharedState(event);
 		state.resetIdentifiers();
-		shareIdentityXDMSharedState(event);
+		resolver.resolve(state.getIdentityProperties().toXDMData(false));
 
 		// dispatch reset complete event
 		final Event responseEvent = new Event.Builder(

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityExtension.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityExtension.java
@@ -21,6 +21,7 @@ import com.adobe.marketing.mobile.EventType;
 import com.adobe.marketing.mobile.Extension;
 import com.adobe.marketing.mobile.ExtensionApi;
 import com.adobe.marketing.mobile.SharedStateResolution;
+import com.adobe.marketing.mobile.SharedStateResolver;
 import com.adobe.marketing.mobile.SharedStateResult;
 import com.adobe.marketing.mobile.SharedStateStatus;
 import com.adobe.marketing.mobile.services.Log;
@@ -268,8 +269,10 @@ class IdentityExtension extends Extension {
 			return;
 		}
 
+		// Add pending shared state to avoid race condition between updating and reading identity map
+		final SharedStateResolver resolver = getApi().createPendingXDMSharedState(event);
 		state.updateCustomerIdentifiers(map);
-		shareIdentityXDMSharedState(event);
+		resolver.resolve(state.getIdentityProperties().toXDMData(false));
 	}
 
 	/**
@@ -296,8 +299,10 @@ class IdentityExtension extends Extension {
 			return;
 		}
 
+		// Add pending shared state to avoid race condition between updating and reading identity map
+		final SharedStateResolver resolver = getApi().createPendingXDMSharedState(event);
 		state.removeCustomerIdentifiers(map);
-		shareIdentityXDMSharedState(event);
+		resolver.resolve(state.getIdentityProperties().toXDMData(false));
 	}
 
 	/**

--- a/code/edgeidentity/src/test/java/com/adobe/marketing/mobile/edge/identity/IdentityExtensionTests.java
+++ b/code/edgeidentity/src/test/java/com/adobe/marketing/mobile/edge/identity/IdentityExtensionTests.java
@@ -687,10 +687,10 @@ public class IdentityExtensionTests {
 		verify(mockIdentityState).updateCustomerIdentifiers(identityMapCaptor.capture());
 		assertEquals(identityXDM, identityMapCaptor.getValue().asXDMMap());
 
-		final ArgumentCaptor<Map<String, Object>> stateCaptor = ArgumentCaptor.forClass(Map.class);
+		// verify pending state is created and resolved
 		verify(mockExtensionApi).createPendingXDMSharedState(eq(updateIdentityEvent));
-		verify(mockSharedStateResolver).resolve(stateCaptor.capture());
-		assertEquals(properties.toXDMData(false), stateCaptor.getValue());
+		verify(mockSharedStateResolver).resolve(eq(properties.toXDMData(false)));
+
 		verify(mockExtensionApi, never()).dispatch(any());
 	}
 
@@ -699,6 +699,7 @@ public class IdentityExtensionTests {
 		// setup
 		final IdentityProperties properties = new IdentityProperties();
 		when(mockIdentityState.getIdentityProperties()).thenReturn(properties);
+		when(mockExtensionApi.createPendingXDMSharedState(any())).thenReturn(mockSharedStateResolver);
 
 		extension = new IdentityExtension(mockExtensionApi, mockIdentityState);
 
@@ -713,10 +714,12 @@ public class IdentityExtensionTests {
 
 		// verify that identifiers are not updated
 		verify(mockIdentityState, never()).updateCustomerIdentifiers(any());
-		// verify that no shared state is created
-		verify(mockExtensionApi, never()).createXDMSharedState(any(), any());
 		// verify that no event is dispatched
 		verify(mockExtensionApi, never()).dispatch(any());
+
+		// verify pending state is created and resolved
+		verify(mockExtensionApi).createPendingXDMSharedState(eq(updateIdentityEvent));
+		verify(mockSharedStateResolver).resolve(eq(properties.toXDMData(false)));
 	}
 
 	@Test
@@ -724,6 +727,7 @@ public class IdentityExtensionTests {
 		// setup
 		final IdentityProperties properties = new IdentityProperties();
 		when(mockIdentityState.getIdentityProperties()).thenReturn(properties);
+		when(mockExtensionApi.createPendingXDMSharedState(any())).thenReturn(mockSharedStateResolver);
 		extension = new IdentityExtension(mockExtensionApi, mockIdentityState);
 
 		// test
@@ -738,10 +742,12 @@ public class IdentityExtensionTests {
 
 		// verify that identifiers are not updated
 		verify(mockIdentityState, never()).updateCustomerIdentifiers(any());
-		// verify that no shared state is created
-		verify(mockExtensionApi, never()).createXDMSharedState(any(), any());
 		// verify that no event is dispatched
 		verify(mockExtensionApi, never()).dispatch(any());
+
+		// verify pending state is created and resolved
+		verify(mockExtensionApi).createPendingXDMSharedState(eq(updateIdentityEvent));
+		verify(mockSharedStateResolver).resolve(eq(properties.toXDMData(false)));
 	}
 
 	// ========================================================================================
@@ -786,12 +792,9 @@ public class IdentityExtensionTests {
 			removedIdentityMapCaptor.getValue().toString()
 		);
 
-		// verify shared state
-		final Map<String, Object> expectedState = properties.toXDMData(false);
-		final ArgumentCaptor<Map<String, Object>> stateCaptor = ArgumentCaptor.forClass(Map.class);
+		// verify pending state is created and resolved
 		verify(mockExtensionApi).createPendingXDMSharedState(eq(removeIdentityEvent));
-		verify(mockSharedStateResolver).resolve(stateCaptor.capture());
-		assertEquals(expectedState, stateCaptor.getValue());
+		verify(mockSharedStateResolver).resolve(eq(properties.toXDMData(false)));
 	}
 
 	@Test
@@ -803,6 +806,7 @@ public class IdentityExtensionTests {
 		);
 		final IdentityProperties properties = new IdentityProperties(identityXDM);
 		when(mockIdentityState.getIdentityProperties()).thenReturn(properties);
+		when(mockExtensionApi.createPendingXDMSharedState(any())).thenReturn(mockSharedStateResolver);
 		extension = new IdentityExtension(mockExtensionApi, mockIdentityState);
 
 		// test
@@ -812,13 +816,17 @@ public class IdentityExtensionTests {
 		// verify identifiers not removed
 		verify(mockIdentityState, never()).removeCustomerIdentifiers(any());
 
-		// verify shared state is never created
-		verify(mockExtensionApi, never()).createXDMSharedState(any(), any());
+		// verify pending state is created and resolved
+		verify(mockExtensionApi).createPendingXDMSharedState(eq(removeIdentityEvent));
+		verify(mockSharedStateResolver).resolve(eq(properties.toXDMData(false)));
 	}
 
 	@Test
 	public void test_handleRemoveIdentity_eventWithEmptyData_returns() {
 		// setup
+		final IdentityProperties properties = new IdentityProperties();
+		when(mockIdentityState.getIdentityProperties()).thenReturn(properties);
+		when(mockExtensionApi.createPendingXDMSharedState(any())).thenReturn(mockSharedStateResolver);
 		extension = new IdentityExtension(mockExtensionApi, mockIdentityState);
 
 		// test
@@ -828,8 +836,9 @@ public class IdentityExtensionTests {
 		// verify identifiers not removed
 		verify(mockIdentityState, never()).removeCustomerIdentifiers(any());
 
-		// verify shared state is never created
-		verify(mockExtensionApi, never()).createXDMSharedState(any(), any());
+		// verify pending state is created and resolved
+		verify(mockExtensionApi).createPendingXDMSharedState(eq(notARemoveIdentityEvent));
+		verify(mockSharedStateResolver).resolve(eq(properties.toXDMData(false)));
 	}
 
 	// ========================================================================================
@@ -894,6 +903,7 @@ public class IdentityExtensionTests {
 	public void test_handleRequestReset() {
 		final IdentityProperties properties = new IdentityProperties();
 		when(mockIdentityState.getIdentityProperties()).thenReturn(properties);
+		when(mockExtensionApi.createPendingXDMSharedState(any())).thenReturn(mockSharedStateResolver);
 
 		extension = new IdentityExtension(mockExtensionApi, mockIdentityState);
 
@@ -903,6 +913,9 @@ public class IdentityExtensionTests {
 		extension.handleRequestReset(resetEvent);
 
 		verify(mockIdentityState).resetIdentifiers();
-		verify(mockExtensionApi).createXDMSharedState(properties.toXDMData(false), resetEvent); // will fail because of new ecid
+
+		// verify pending state is created and resolved
+		verify(mockExtensionApi).createPendingXDMSharedState(eq(resetEvent));
+		verify(mockSharedStateResolver).resolve(eq(properties.toXDMData(false)));
 	}
 }


### PR DESCRIPTION
Set a pending shared state before update and remove Identity Map operations.

## Description

A race condition can occur when updating the IdentityMap followed by an Edge.sendEvent() call. The issue is the Identity extension doesn't finish processing the update to the IdentityMap before the Edge extension retrieves the Identity shared state. This causes the Edge Network request to use the IdentityMap before the update.

The fix is to simply create a pending shared state before any updates to the Identity Map in IdentityProperties. After the Identity Map is edited, the pending shared state is resolved with the new Identity Map XDM.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
