### PR TITLE
Fix use of 'allowEmpty' parameter in IdentityProperties.toXDMData()

### DIFF
--- a/code/edgeidentity/src/androidTest/java/com/adobe/marketing/mobile/edge/identity/IdentityECIDHandlingTest.java
+++ b/code/edgeidentity/src/androidTest/java/com/adobe/marketing/mobile/edge/identity/IdentityECIDHandlingTest.java
@@ -66,7 +66,7 @@ public class IdentityECIDHandlingTest {
 	public void testECID_edgePersistenceTakesPreferenceOverDirectExtension() throws Exception {
 		// setup
 		setIdentityDirectPersistedECID("legacyECID");
-		setEdgeIdentityPersistence(createIdentityMap("ECID", "edgeECID").asXDMMap());
+		setEdgeIdentityPersistence(createIdentityMap("ECID", "edgeECID").asXDMMap(false));
 		registerExtensions(Arrays.asList(MonitorExtension.EXTENSION, Identity.EXTENSION), null);
 
 		// verify
@@ -217,7 +217,7 @@ public class IdentityECIDHandlingTest {
 	public void testECID_DirectEcidIsRemovedOnPrivacyOptOut() throws Exception {
 		// setup
 		setIdentityDirectPersistedECID("legacyECID");
-		setEdgeIdentityPersistence(createIdentityMap("ECID", "edgeECID").asXDMMap());
+		setEdgeIdentityPersistence(createIdentityMap("ECID", "edgeECID").asXDMMap(false));
 
 		registerExtensions(
 			Arrays.asList(

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityExtension.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityExtension.java
@@ -259,7 +259,7 @@ class IdentityExtension extends Extension {
 
 		if (eventData == null) {
 			Log.trace(LOG_TAG, LOG_SOURCE, "Cannot update identifiers, event data is null.");
-			resolver.resolve(state.getIdentityProperties().toXDMData(false));
+			resolver.resolve(state.getIdentityProperties().toXDMData());
 			return;
 		}
 
@@ -271,12 +271,12 @@ class IdentityExtension extends Extension {
 				LOG_SOURCE,
 				"Failed to update identifiers as no identifiers were found in the event data."
 			);
-			resolver.resolve(state.getIdentityProperties().toXDMData(false));
+			resolver.resolve(state.getIdentityProperties().toXDMData());
 			return;
 		}
 
 		state.updateCustomerIdentifiers(map);
-		resolver.resolve(state.getIdentityProperties().toXDMData(false));
+		resolver.resolve(state.getIdentityProperties().toXDMData());
 	}
 
 	/**
@@ -292,7 +292,7 @@ class IdentityExtension extends Extension {
 
 		if (eventData == null) {
 			Log.trace(LOG_TAG, LOG_SOURCE, "Cannot remove identifiers, event data is null.");
-			resolver.resolve(state.getIdentityProperties().toXDMData(false));
+			resolver.resolve(state.getIdentityProperties().toXDMData());
 			return;
 		}
 
@@ -304,12 +304,12 @@ class IdentityExtension extends Extension {
 				LOG_SOURCE,
 				"Failed to remove identifiers as no identifiers were found in the event data."
 			);
-			resolver.resolve(state.getIdentityProperties().toXDMData(false));
+			resolver.resolve(state.getIdentityProperties().toXDMData());
 			return;
 		}
 
 		state.removeCustomerIdentifiers(map);
-		resolver.resolve(state.getIdentityProperties().toXDMData(false));
+		resolver.resolve(state.getIdentityProperties().toXDMData());
 	}
 
 	/**
@@ -318,7 +318,7 @@ class IdentityExtension extends Extension {
 	 * @param event the identity request {@link Event}
 	 */
 	private void handleGetIdentifiersRequest(@NonNull final Event event) {
-		final Map<String, Object> xdmData = state.getIdentityProperties().toXDMData(false);
+		final Map<String, Object> xdmData = state.getIdentityProperties().toXDMData(true);
 		final Event responseEvent = new Event.Builder(
 			IdentityConstants.EventNames.IDENTITY_RESPONSE_CONTENT_ONE_TIME,
 			EventType.EDGE_IDENTITY,
@@ -340,7 +340,7 @@ class IdentityExtension extends Extension {
 		// Add pending shared state to avoid race condition between updating and reading identity map
 		final SharedStateResolver resolver = getApi().createPendingXDMSharedState(event);
 		state.resetIdentifiers();
-		resolver.resolve(state.getIdentityProperties().toXDMData(false));
+		resolver.resolve(state.getIdentityProperties().toXDMData());
 
 		// dispatch reset complete event
 		final Event responseEvent = new Event.Builder(
@@ -403,6 +403,6 @@ class IdentityExtension extends Extension {
 	 * @param event the {@link Event} that triggered the XDM shared state change
 	 */
 	private void shareIdentityXDMSharedState(final Event event) {
-		sharedStateHandle.createXDMSharedState(state.getIdentityProperties().toXDMData(false), event);
+		sharedStateHandle.createXDMSharedState(state.getIdentityProperties().toXDMData(), event);
 	}
 }

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityMap.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityMap.java
@@ -230,20 +230,10 @@ public class IdentityMap {
 	}
 
 	/**
-	 * Use this method to cast the {@link IdentityMap} as {@code Map<String, Object>} to be passed as EventData for an SDK Event.
-	 * This method returns an empty map if the {@code IdentityMap} contains no data
-	 *
-	 * @return {@code Map} representation of xdm formatted IdentityMap
-	 */
-	Map<String, Object> asXDMMap() {
-		return asXDMMap(true);
-	}
-
-	/**
 	 * Use this method to cast the {@link IdentityMap} as {@code Map<String,Object>} to be passed as EventData for an SDK Event.
 	 *
-	 * @param allowEmpty If false and if this {@code IdentityMap} contains no data, then returns a map with empty xdmFormatted Identity Map.
-	 *                   If true and if this {@code IdentityMap} contains no data, then returns an empty map
+	 * @param allowEmpty If true and if this {@code IdentityMap} contains no data, then returns a map with empty xdmFormatted Identity Map.
+	 *                   If false and if this {@code IdentityMap} contains no data, then returns an empty map
 	 * @return {@code Map} representation of xdm formatted IdentityMap
 	 */
 	Map<String, Object> asXDMMap(final boolean allowEmpty) {
@@ -260,7 +250,7 @@ public class IdentityMap {
 			identityMap.put(namespace, namespaceIds);
 		}
 
-		if (!identityMap.isEmpty() || !allowEmpty) {
+		if (!identityMap.isEmpty() || allowEmpty) {
 			xdmMap.put(IdentityConstants.XDMKeys.IDENTITY_MAP, identityMap);
 		}
 

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityProperties.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityProperties.java
@@ -224,9 +224,21 @@ class IdentityProperties {
 	}
 
 	/**
-	 * Converts this into an event data representation in XDM format
+	 * Converts this {@code IdentityProperties} into an event data representation in XDM format
+	 * Use this method to cast the {@link IdentityMap} as {@code Map<String, Object>} to be passed as EventData for an SDK Event.
+	 * This method returns an empty map if the {@code IdentityMap} contains no data
 	 *
-	 * @param allowEmpty If this {@link IdentityProperties} contains no data, return a dictionary with a single {@link IdentityMap} key
+	 * @return A {@link Map} representing this in XDM format, or an empty {@link Map} if this contains no data.
+	 */
+	Map<String, Object> toXDMData() {
+		return toXDMData(false);
+	}
+
+	/**
+	 * Converts this {@code IdentityProperties} into an event data representation in XDM format
+	 *
+	 * @param allowEmpty If this {@link IdentityProperties} contains no data, return a dictionary with a single {@link IdentityMap} key,
+	 *                   otherwise an empty map is returned.
 	 * @return A {@link Map} representing this in XDM format
 	 */
 	Map<String, Object> toXDMData(final boolean allowEmpty) {

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityState.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityState.java
@@ -137,7 +137,7 @@ class IdentityState {
 
 		hasBooted = true;
 		Log.debug(LOG_TAG, LOG_SOURCE, "Edge Identity has successfully booted up");
-		callback.createXDMSharedState(identityProperties.toXDMData(false), null);
+		callback.createXDMSharedState(identityProperties.toXDMData(), null);
 
 		return hasBooted;
 	}
@@ -209,7 +209,7 @@ class IdentityState {
 
 		// Save to persistence
 		identityStorageManager.savePropertiesToPersistence(identityProperties);
-		callback.createXDMSharedState(identityProperties.toXDMData(false), event);
+		callback.createXDMSharedState(identityProperties.toXDMData(), event);
 	}
 
 	/**

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityStorageManager.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityStorageManager.java
@@ -99,7 +99,7 @@ class IdentityStorageManager {
 			return;
 		}
 
-		final JSONObject jsonObject = new JSONObject(properties.toXDMData(false));
+		final JSONObject jsonObject = new JSONObject(properties.toXDMData());
 		final String jsonString = jsonObject.toString();
 		edgeIdentityStore.setString(IdentityConstants.DataStoreKey.IDENTITY_PROPERTIES, jsonString);
 	}

--- a/code/edgeidentity/src/test/java/com/adobe/marketing/mobile/edge/identity/IdentityExtensionTests.java
+++ b/code/edgeidentity/src/test/java/com/adobe/marketing/mobile/edge/identity/IdentityExtensionTests.java
@@ -685,7 +685,7 @@ public class IdentityExtensionTests {
 		// verify identifiers updated
 		final ArgumentCaptor<IdentityMap> identityMapCaptor = ArgumentCaptor.forClass(IdentityMap.class);
 		verify(mockIdentityState).updateCustomerIdentifiers(identityMapCaptor.capture());
-		assertEquals(identityXDM, identityMapCaptor.getValue().asXDMMap());
+		assertEquals(identityXDM, identityMapCaptor.getValue().asXDMMap(false));
 
 		// verify pending state is created and resolved
 		verify(mockExtensionApi).createPendingXDMSharedState(eq(updateIdentityEvent));

--- a/code/edgeidentity/src/test/java/com/adobe/marketing/mobile/edge/identity/IdentityMapTests.java
+++ b/code/edgeidentity/src/test/java/com/adobe/marketing/mobile/edge/identity/IdentityMapTests.java
@@ -31,7 +31,7 @@ public class IdentityMapTests {
 		map.addItem(new IdentityItem("California"), "location");
 
 		// verify
-		IdentityTestUtil.flattenMap(map.asXDMMap()).get("identityMap.location[0].id");
+		IdentityTestUtil.flattenMap(map.asXDMMap(false)).get("identityMap.location[0].id");
 	}
 
 	@Test
@@ -148,7 +148,7 @@ public class IdentityMapTests {
 		baseMap.merge(newMap);
 
 		// verify the existing identityMap is unchanged
-		Map<String, String> flattenedMap = IdentityTestUtil.flattenMap(baseMap.asXDMMap());
+		Map<String, String> flattenedMap = IdentityTestUtil.flattenMap(baseMap.asXDMMap(false));
 		assertEquals(3, flattenedMap.size());
 		assertEquals("California", flattenedMap.get("identityMap.location[0].id"));
 		assertEquals("authenticated", flattenedMap.get("identityMap.location[0].authenticatedState"));
@@ -219,7 +219,7 @@ public class IdentityMapTests {
 
 		// test
 		emptyMap.clearItemsForNamespace("location");
-		assertTrue(emptyMap.asXDMMap().isEmpty());
+		assertTrue(emptyMap.asXDMMap(false).isEmpty());
 	}
 
 	@Test
@@ -301,7 +301,7 @@ public class IdentityMapTests {
 		IdentityMap map = IdentityMap.fromXDMMap(xdmData);
 
 		// verify
-		Map<String, String> flattenedMap = IdentityTestUtil.flattenMap(map.asXDMMap());
+		Map<String, String> flattenedMap = IdentityTestUtil.flattenMap(map.asXDMMap(false));
 		assertEquals("randomECID", flattenedMap.get("identityMap.ECID[0].id"));
 		assertEquals("ambiguous", flattenedMap.get("identityMap.ECID[0].authenticatedState"));
 		assertEquals("true", flattenedMap.get("identityMap.ECID[0].primary"));
@@ -387,16 +387,16 @@ public class IdentityMapTests {
 	}
 
 	@Test
-	public void testAsXDMMap_AllowEmptyTrue() {
+	public void testAsXDMMap_AllowEmptyFalse() {
 		IdentityMap map = new IdentityMap();
-		Map xdmMap = map.asXDMMap(true);
+		Map xdmMap = map.asXDMMap(false);
 		assertTrue(xdmMap.isEmpty());
 	}
 
 	@Test
-	public void testAsXDMMap_AllowEmptyFalse() {
+	public void testAsXDMMap_AllowEmptyTrue() {
 		IdentityMap map = new IdentityMap();
-		Map xdmMap = map.asXDMMap(false);
+		Map xdmMap = map.asXDMMap(true);
 
 		// verify that the base xdm key identityMap is present
 		assertEquals(1, xdmMap.size());
@@ -404,7 +404,7 @@ public class IdentityMapTests {
 	}
 
 	private Map<String, List<IdentityItem>> getCastedIdentityMap(final IdentityMap map) {
-		final Map<String, Object> xdmMap = map.asXDMMap();
+		final Map<String, Object> xdmMap = map.asXDMMap(false);
 		return (Map<String, List<IdentityItem>>) xdmMap.get(IdentityConstants.XDMKeys.IDENTITY_MAP);
 	}
 

--- a/code/edgeidentity/src/test/java/com/adobe/marketing/mobile/edge/identity/IdentityPropertiesTests.java
+++ b/code/edgeidentity/src/test/java/com/adobe/marketing/mobile/edge/identity/IdentityPropertiesTests.java
@@ -13,8 +13,12 @@ package com.adobe.marketing.mobile.edge.identity;
 
 import static com.adobe.marketing.mobile.edge.identity.IdentityTestUtil.*;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
+import com.adobe.marketing.mobile.util.DataReader;
+import com.adobe.marketing.mobile.util.DataReaderException;
 import java.util.Map;
 import org.junit.Test;
 
@@ -25,12 +29,30 @@ public class IdentityPropertiesTests {
 	// ======================================================================================================================
 
 	@Test
-	public void test_toXDMData_AllowEmpty() {
+	public void test_toXDMData_AllowEmpty_True() throws DataReaderException {
 		// setup
 		IdentityProperties props = new IdentityProperties();
 
 		// test
 		Map<String, Object> xdmMap = props.toXDMData(true);
+
+		// verify
+		Map<String, Object> identityMap = DataReader.getTypedMap(
+			Object.class,
+			xdmMap,
+			IdentityConstants.XDMKeys.IDENTITY_MAP
+		);
+		assertNotNull(identityMap);
+		assertTrue(identityMap.isEmpty());
+	}
+
+	@Test
+	public void test_toXDMData_AllowEmpty_False() {
+		// setup
+		IdentityProperties props = new IdentityProperties();
+
+		// test
+		Map<String, Object> xdmMap = props.toXDMData(false);
 
 		// verify
 		assertNull(xdmMap.get(IdentityConstants.XDMKeys.IDENTITY_MAP));

--- a/code/edgeidentity/src/test/java/com/adobe/marketing/mobile/edge/identity/IdentityTests.java
+++ b/code/edgeidentity/src/test/java/com/adobe/marketing/mobile/edge/identity/IdentityTests.java
@@ -628,7 +628,7 @@ public class IdentityTests {
 		assertEquals(IdentityConstants.EventNames.UPDATE_IDENTITIES, dispatchedEvent.getName());
 		assertEquals(EventType.EDGE_IDENTITY, dispatchedEvent.getType());
 		assertEquals(EventSource.UPDATE_IDENTITY, dispatchedEvent.getSource());
-		assertEquals(map.asXDMMap(), dispatchedEvent.getEventData());
+		assertEquals(map.asXDMMap(false), dispatchedEvent.getEventData());
 	}
 
 	@Test
@@ -685,7 +685,7 @@ public class IdentityTests {
 
 		final IdentityMap expectedIdentityMap = new IdentityMap();
 		expectedIdentityMap.addItem(sampleItem, "namespace");
-		assertEquals(expectedIdentityMap.asXDMMap(), dispatchedEvent.getEventData());
+		assertEquals(expectedIdentityMap.asXDMMap(false), dispatchedEvent.getEventData());
 	}
 
 	@Test


### PR DESCRIPTION
Fix use of 'allowEmpty' parameter in IdentityProperties.toXDMData() to match use in iOS implementation.

## Description

In Android, the 'allowEmpty' parameter in IdentityProperties.toXDMData() and IdentityMap.asXDMMap() has the opposite meaning as in the iOS Edge Identity implementation. This fixes that by making 'allowEmpty' to mean the resulting Map will contain an "identityMap" top-level object when the IdentityMap is empty.

Updated getIdentifiers API request by setting "allowEmpty = true" in IdentityExtension.handleGetIdentifiersRequest. If allowEmpty is false and an empty Map (and empty EventData) is returned then the API returns an AdobeError to the caller instead of an empty XDM IdentityMap. This is the only use of "allowEmpty = true" outside of test code.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
