### PR TITLE
Refactor functional test helper to use NamedCollection

### DIFF
--- a/code/edgeidentity/src/androidTest/java/com/adobe/marketing/mobile/edge/identity/util/TestPersistenceHelper.java
+++ b/code/edgeidentity/src/androidTest/java/com/adobe/marketing/mobile/edge/identity/util/TestPersistenceHelper.java
@@ -11,7 +11,6 @@
 
 package com.adobe.marketing.mobile.edge.identity.util;
 
-import android.content.SharedPreferences;
 import com.adobe.marketing.mobile.services.NamedCollection;
 import com.adobe.marketing.mobile.services.ServiceProvider;
 import java.util.ArrayList;
@@ -30,7 +29,7 @@ public class TestPersistenceHelper {
 	};
 
 	/**
-	 * Helper method to update the {@link SharedPreferences} data.
+	 * Helper method to update the {@link NamedCollection} data.
 	 *
 	 * @param datastore the name of the datastore to be updated
 	 * @param key       the persisted data key that has to be updated
@@ -47,7 +46,7 @@ public class TestPersistenceHelper {
 	 *
 	 * @param datastore the name of the datastore to be read
 	 * @param key       the key that needs to be read
-	 * @return {@link String} value of persisted data. Null if data is not found in {@link SharedPreferences}
+	 * @return {@link String} value of persisted data. {@code null} if data is not found in {@link NamedCollection}
 	 */
 	public static String readPersistedData(final String datastore, final String key) {
 		NamedCollection dataStore = ServiceProvider.getInstance().getDataStoreService().getNamedCollection(datastore);

--- a/code/edgeidentity/src/androidTest/java/com/adobe/marketing/mobile/edge/identity/util/TestPersistenceHelper.java
+++ b/code/edgeidentity/src/androidTest/java/com/adobe/marketing/mobile/edge/identity/util/TestPersistenceHelper.java
@@ -11,11 +11,9 @@
 
 package com.adobe.marketing.mobile.edge.identity.util;
 
-import static org.junit.Assert.fail;
-
-import android.app.Application;
-import android.content.Context;
 import android.content.SharedPreferences;
+import com.adobe.marketing.mobile.services.NamedCollection;
+import com.adobe.marketing.mobile.services.ServiceProvider;
 import java.util.ArrayList;
 
 /**
@@ -39,31 +37,9 @@ public class TestPersistenceHelper {
 	 * @param value     the new value
 	 */
 	public static void updatePersistence(final String datastore, final String key, final String value) {
-		final Application application = TestHelper.defaultApplication;
+		NamedCollection dataStore = ServiceProvider.getInstance().getDataStoreService().getNamedCollection(datastore);
 
-		if (application == null) {
-			fail(
-				"Unable to updatePersistence by TestPersistenceHelper. Application is null, fast failing the test case."
-			);
-		}
-
-		final Context context = application.getApplicationContext();
-
-		if (context == null) {
-			fail("Unable to updatePersistence by TestPersistenceHelper. Context is null, fast failing the test case.");
-		}
-
-		SharedPreferences sharedPreferences = context.getSharedPreferences(datastore, Context.MODE_PRIVATE);
-
-		if (sharedPreferences == null) {
-			fail(
-				"Unable to updatePersistence by TestPersistenceHelper. sharedPreferences is null, fast failing the test case."
-			);
-		}
-
-		SharedPreferences.Editor editor = sharedPreferences.edit();
-		editor.putString(key, value);
-		editor.apply();
+		dataStore.setString(key, value);
 	}
 
 	/**
@@ -74,61 +50,22 @@ public class TestPersistenceHelper {
 	 * @return {@link String} value of persisted data. Null if data is not found in {@link SharedPreferences}
 	 */
 	public static String readPersistedData(final String datastore, final String key) {
-		final Application application = TestHelper.defaultApplication;
+		NamedCollection dataStore = ServiceProvider.getInstance().getDataStoreService().getNamedCollection(datastore);
 
-		if (application == null) {
-			fail(
-				"Unable to readPersistedData by TestPersistenceHelper. Application is null, fast failing the test case."
-			);
-		}
-
-		final Context context = application.getApplicationContext();
-
-		if (context == null) {
-			fail("Unable to readPersistedData by TestPersistenceHelper. Context is null, fast failing the test case.");
-		}
-
-		SharedPreferences sharedPreferences = context.getSharedPreferences(datastore, Context.MODE_PRIVATE);
-
-		if (sharedPreferences == null) {
-			fail(
-				"Unable to readPersistedData by TestPersistenceHelper. sharedPreferences is null, fast failing the test case."
-			);
-		}
-
-		return sharedPreferences.getString(key, null);
+		return dataStore.getString(key, null);
 	}
 
 	/**
 	 * Clears the Configuration and Consent extension's persisted data
 	 */
 	public static void resetKnownPersistence() {
-		final Application application = TestHelper.defaultApplication;
-
-		if (application == null) {
-			fail(
-				"Unable to resetPersistence by TestPersistenceHelper. Application is null, fast failing the test case."
-			);
-		}
-
-		final Context context = application.getApplicationContext();
-
-		if (context == null) {
-			fail("Unable to resetPersistence by TestPersistenceHelper. Context is null, fast failing the test case.");
-		}
-
 		for (String eachDatastore : knownDatastoreName) {
-			SharedPreferences sharedPreferences = context.getSharedPreferences(eachDatastore, Context.MODE_PRIVATE);
+			NamedCollection dataStore = ServiceProvider
+				.getInstance()
+				.getDataStoreService()
+				.getNamedCollection(eachDatastore);
 
-			if (sharedPreferences == null) {
-				fail(
-					"Unable to resetPersistence by TestPersistenceHelper. sharedPreferences is null, fast failing the test case."
-				);
-			}
-
-			SharedPreferences.Editor editor = sharedPreferences.edit();
-			editor.clear();
-			editor.apply();
+			dataStore.removeAll();
 		}
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR refactors the functional test's `TestPersistenceHelper` class to use the newly provided in Core 2.0 `NamedCollection` APIs instead of using Android SharedPreferences directly.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
