### PR TITLE
Do not allow IdentityItems with empty ids (resolves #100)

### DIFF
--- a/Documentation/api-reference.md
+++ b/Documentation/api-reference.md
@@ -432,7 +432,7 @@ Identity.updateIdentities(identityMap)
 
 ### IdentityMap
 
-Defines a map containing a set of end user identities, keyed on either namespace integration code or the namespace ID of the identity. The values of the map are an array, meaning that more than one identity of each namespace may be carried.
+Defines a map containing a set of end user identities, keyed on either namespace integration code or the namespace ID of the identity. The values of the map are an array, meaning that more than one identity of each namespace may be carried. Identities, represented by [IdentityItem](#identityitem) objects, may not have null or empty identitifers and are ignored when adding to the IdentityMap.
 
 The format of the IdentityMap class is defined by the [XDM Identity Map Schema](https://github.com/adobe/xdm/blob/master/docs/reference/mixins/shared/identitymap.schema.md).
 
@@ -523,7 +523,7 @@ val hasNotIdentities = identityMap.isEmpty()
 
 ### IdentityItem
 
-Defines an identity to be included in an [IdentityMap](#identitymap).
+Defines an identity to be included in an [IdentityMap](#identitymap). IdentityItems may not have null or empty identifiers and are ignored when adding to an [IdentityMap](#identitymap) instance.
 
 The format of the IdentityItem class is defined by the [XDM Identity Item Schema](https://github.com/adobe/xdm/blob/master/docs/reference/datatypes/identityitem.schema.md).
 
@@ -566,7 +566,7 @@ val primary = item.isPrimary
 
 ### AuthenticatedState
 
-Defines the state an [Identity Item](#identityitem) is authenticated for.
+Defines the state for which an [Identity Item](#identityitem) is authenticated.
 
 The possible authenticated states are:
 

--- a/Documentation/api-reference.md
+++ b/Documentation/api-reference.md
@@ -432,7 +432,7 @@ Identity.updateIdentities(identityMap)
 
 ### IdentityMap
 
-Defines a map containing a set of end user identities, keyed on either namespace integration code or the namespace ID of the identity. The values of the map are an array, meaning that more than one identity of each namespace may be carried. Identities, represented by [IdentityItem](#identityitem) objects, may not have null or empty identitifers and are ignored when adding to the IdentityMap.
+Defines a map containing a set of end user identities, keyed on either namespace integration code or the namespace ID of the identity. The values of the map are an array of [IdentityItem](@identityitem)s, meaning that more than one identity of each namespace may be carried. Each IdentityItem should have a valid, non-null and non-empty identifier, otherwise it will be ignored.
 
 The format of the IdentityMap class is defined by the [XDM Identity Map Schema](https://github.com/adobe/xdm/blob/master/docs/reference/mixins/shared/identitymap.schema.md).
 

--- a/Documentation/api-reference.md
+++ b/Documentation/api-reference.md
@@ -432,7 +432,7 @@ Identity.updateIdentities(identityMap)
 
 ### IdentityMap
 
-Defines a map containing a set of end user identities, keyed on either namespace integration code or the namespace ID of the identity. The values of the map are an array of [IdentityItem](@identityitem)s, meaning that more than one identity of each namespace may be carried. Each IdentityItem should have a valid, non-null and non-empty identifier, otherwise it will be ignored.
+Defines a map containing a set of end user identities, keyed on either namespace integration code or the namespace ID of the identity. The values of the map are an array of [IdentityItem](#identityitem)s, meaning that more than one identity of each namespace may be carried. Each IdentityItem should have a valid, non-null and non-empty identifier, otherwise it will be ignored.
 
 The format of the IdentityMap class is defined by the [XDM Identity Map Schema](https://github.com/adobe/xdm/blob/master/docs/reference/mixins/shared/identitymap.schema.md).
 

--- a/code/edgeidentity/src/androidTest/java/com/adobe/marketing/mobile/edge/identity/IdentityPublicAPITest.java
+++ b/code/edgeidentity/src/androidTest/java/com/adobe/marketing/mobile/edge/identity/IdentityPublicAPITest.java
@@ -364,6 +364,36 @@ public class IdentityPublicAPITest {
 	}
 
 	@Test
+	public void testGetIdentities_itemWithEmptyId_notAddedToMap() {
+		registerExtensions(Arrays.asList(MonitorExtension.EXTENSION, Identity.EXTENSION), null);
+
+		// setup
+		// update Identities through API
+		IdentityMap map = new IdentityMap();
+		map.addItem(new IdentityItem("primary@email.com"), "Email");
+		map.addItem(new IdentityItem("secondary@email.com"), "Email");
+		map.addItem(new IdentityItem("zzzyyyxxx"), "UserId");
+		map.addItem(new IdentityItem(""), "UserId");
+		map.addItem(new IdentityItem("John Doe"), "UserName");
+		map.addItem(new IdentityItem(""), "EmptyNamespace");
+		Identity.updateIdentities(map);
+
+		// test
+		Map<String, Object> getIdentitiesResponse = getIdentitiesSync();
+		waitForThreads(2000);
+
+		// verify
+		IdentityMap responseMap = (IdentityMap) getIdentitiesResponse.get(
+			IdentityTestConstants.GetIdentitiesHelper.VALUE
+		);
+		assertEquals(4, responseMap.getNamespaces().size());
+		assertEquals(2, responseMap.getIdentityItemsForNamespace("Email").size());
+		assertEquals(1, responseMap.getIdentityItemsForNamespace("UserId").size());
+		assertEquals(1, responseMap.getIdentityItemsForNamespace("UserName").size());
+		assertEquals(1, responseMap.getIdentityItemsForNamespace("ECID").size());
+	}
+
+	@Test
 	public void testGetIdentities_nullCallback() {
 		registerExtensions(Arrays.asList(MonitorExtension.EXTENSION, Identity.EXTENSION), null);
 

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityItem.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityItem.java
@@ -43,7 +43,7 @@ public final class IdentityItem {
 	 * @param id                 id for the item; should not be null
 	 * @param authenticatedState {@link AuthenticatedState} for the item; if none is provided {@link AuthenticatedState#AMBIGUOUS} is used as default
 	 * @param primary            primary flag for the item
-	 * @throws IllegalArgumentException if id is null
+	 * @throws IllegalArgumentException if id is null or empty
 	 */
 	public IdentityItem(
 		@NonNull final String id,
@@ -65,6 +65,7 @@ public final class IdentityItem {
 	 * (@code primary} is set to false
 	 *
 	 * @param id the id for this {@link IdentityItem}; should not be null
+	 * @throws IllegalArgumentException if id is null or empty
 	 */
 	public IdentityItem(@NonNull final String id) {
 		this(id, AuthenticatedState.AMBIGUOUS, false);

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityItem.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityItem.java
@@ -18,6 +18,7 @@ import androidx.annotation.Nullable;
 import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.util.DataReader;
 import com.adobe.marketing.mobile.util.DataReaderException;
+import com.adobe.marketing.mobile.util.StringUtils;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -49,8 +50,8 @@ public final class IdentityItem {
 		@Nullable final AuthenticatedState authenticatedState,
 		final boolean primary
 	) {
-		if (id == null) {
-			throw new IllegalArgumentException("id must be non-null");
+		if (StringUtils.isNullOrEmpty(id)) {
+			throw new IllegalArgumentException("id must be non-null and non-empty");
 		}
 
 		this.id = id;
@@ -193,7 +194,15 @@ public final class IdentityItem {
 			return new IdentityItem(id, authenticatedState, primary);
 		} catch (final DataReaderException e) {
 			Log.debug(LOG_TAG, LOG_SOURCE, "Failed to create IdentityItem from data.");
-			return null;
+		} catch (final IllegalArgumentException e) {
+			Log.debug(
+				LOG_TAG,
+				LOG_SOURCE,
+				"Failed to create IdentityItem from data as 'id' is null or empty. %s",
+				e.getLocalizedMessage()
+			);
 		}
+
+		return null;
 	}
 }

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityItem.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityItem.java
@@ -65,9 +65,11 @@ public final class IdentityItem {
 	 * Creates a new {@link IdentityItem} with default values
 	 * {@code authenticatedState) is set to AMBIGUOUS
 	 * (@code primary} is set to false
+	 * An {@code IdentityItem} should not have an empty or null {@code id} value. An {@link IdentityMap}
+	 * will reject {@code IdentityItem}s with null or empty identifiers.
 	 *
 	 * @param id the id for this {@link IdentityItem}; should not be null
-	 * @throws IllegalArgumentException if id is null or empty
+	 * @throws IllegalArgumentException if {@code id} is null
 	 */
 	public IdentityItem(@NonNull final String id) {
 		this(id, AuthenticatedState.AMBIGUOUS, false);

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityItem.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityItem.java
@@ -18,7 +18,6 @@ import androidx.annotation.Nullable;
 import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.util.DataReader;
 import com.adobe.marketing.mobile.util.DataReaderException;
-import com.adobe.marketing.mobile.util.StringUtils;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -38,20 +37,23 @@ public final class IdentityItem {
 	private final boolean primary;
 
 	/**
-	 * Creates a new {@link IdentityItem}
+	 * Creates a new {@link IdentityItem}.
+	 * An {@code IdentityItem} should not have an empty or null {@code id} value. An {@link IdentityMap}
+	 * will reject {@code IdentityItem}s with null or empty identifiers.
+	 *
 	 *
 	 * @param id                 id for the item; should not be null
 	 * @param authenticatedState {@link AuthenticatedState} for the item; if none is provided {@link AuthenticatedState#AMBIGUOUS} is used as default
 	 * @param primary            primary flag for the item
-	 * @throws IllegalArgumentException if id is null or empty
+	 * @throws IllegalArgumentException if {@code id} is null
 	 */
 	public IdentityItem(
 		@NonNull final String id,
 		@Nullable final AuthenticatedState authenticatedState,
 		final boolean primary
 	) {
-		if (StringUtils.isNullOrEmpty(id)) {
-			throw new IllegalArgumentException("id must be non-null and non-empty");
+		if (id == null) {
+			throw new IllegalArgumentException("id must be non-null");
 		}
 
 		this.id = id;
@@ -199,7 +201,7 @@ public final class IdentityItem {
 			Log.debug(
 				LOG_TAG,
 				LOG_SOURCE,
-				"Failed to create IdentityItem from data as 'id' is null or empty. %s",
+				"Failed to create IdentityItem from data as 'id' is null. %s",
 				e.getLocalizedMessage()
 			);
 		}

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityMap.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityMap.java
@@ -79,6 +79,7 @@ public class IdentityMap {
 	/**
 	 * Add an identity item which is used to clearly distinguish entities that are interacting
 	 * with digital experiences.
+	 * An {@link IdentityItem} with an empty {@code id} is not allowed and is ignored.
 	 *
 	 * @param item      {@link IdentityItem} to be added to the given {@code namespace}; should not be null
 	 * @param namespace the namespace integration code or namespace ID of the identity; should not be null
@@ -152,6 +153,7 @@ public class IdentityMap {
 	/**
 	 * Add an identity item which is used to clearly distinguish entities that are interacting
 	 * with digital experiences.
+	 * An {@link IdentityItem} with an empty {@code id} is not allowed and is ignored.
 	 *
 	 * @param item        {@link IdentityItem} to be added to the namespace
 	 * @param namespace   the namespace integration code or namespace ID of the identity
@@ -174,6 +176,7 @@ public class IdentityMap {
 	/**
 	 * Merge the given map on to this {@link IdentityMap}. Any {@link IdentityItem} in map which shares the same
 	 * namespace and id as an item in this {@code IdentityMap} will replace that {@code IdentityItem}.
+	 * Any {@link IdentityItem}s with an empty {@code id} are not allowed and are ignored.
 	 *
 	 * @param map {@link IdentityMap} to be merged into this object
 	 */

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityMap.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityMap.java
@@ -313,6 +313,16 @@ public class IdentityMap {
 	// ========================================================================================
 
 	private void addItemToMap(final IdentityItem newItem, final String namespace, final boolean isFirstItem) {
+		if (StringUtils.isNullOrEmpty(newItem.getId())) {
+			Log.debug(
+				LOG_TAG,
+				LOG_SOURCE,
+				"Unable to add IdentityItem to IdentityMap with null or empty identifier value: %s",
+				newItem
+			);
+			return;
+		}
+
 		// check if namespace exists
 		final List<IdentityItem> itemList;
 

--- a/code/edgeidentity/src/test/java/com/adobe/marketing/mobile/edge/identity/IdentityItemTests.java
+++ b/code/edgeidentity/src/test/java/com/adobe/marketing/mobile/edge/identity/IdentityItemTests.java
@@ -41,9 +41,14 @@ public class IdentityItemTests {
 		IdentityItem item = new IdentityItem(null, AuthenticatedState.AUTHENTICATED, true);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testIdentityItem_ctor1_emptyId_throwIllegalArgumentException() {
+	@Test
+	public void testIdentityItem_ctor1_emptyId() {
 		IdentityItem item = new IdentityItem("", AuthenticatedState.AUTHENTICATED, true);
+
+		// For backward compatibility, an IdentityItem can contain empty identifiers.
+		assertEquals("", item.getId());
+		assertEquals("authenticated", item.getAuthenticatedState().getName());
+		assertTrue(item.isPrimary());
 	}
 
 	@Test(expected = IllegalArgumentException.class)
@@ -51,9 +56,14 @@ public class IdentityItemTests {
 		IdentityItem item = new IdentityItem((String) null);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testIdentityItem_ctor2_emptyId_throwIllegalArgumentException() {
+	@Test
+	public void testIdentityItem_ctor2_emptyId() {
 		IdentityItem item = new IdentityItem("");
+
+		// For backward compatibility, an IdentityItem can contain empty identifiers.
+		assertEquals("", item.getId());
+		assertEquals("ambiguous", item.getAuthenticatedState().getName());
+		assertFalse(item.isPrimary());
 	}
 
 	@Test
@@ -141,14 +151,19 @@ public class IdentityItemTests {
 	}
 
 	@Test
-	public void testIdentityItem_fromData_emptyId_returnNull() {
+	public void testIdentityItem_fromData_emptyId() {
 		// setup
 		Map<String, Object> map = new HashMap<>();
 		map.put("id", "");
 		map.put("authenticatedState", "loggedOut");
 		map.put("primary", false);
 
-		assertNull(IdentityItem.fromData(map));
+		IdentityItem item = IdentityItem.fromData(map);
+
+		// For backward compatibility, an IdentityItem can contain empty identifiers.
+		assertEquals("", item.getId());
+		assertEquals("loggedOut", item.getAuthenticatedState().getName());
+		assertFalse(item.isPrimary());
 	}
 
 	@Test

--- a/code/edgeidentity/src/test/java/com/adobe/marketing/mobile/edge/identity/IdentityItemTests.java
+++ b/code/edgeidentity/src/test/java/com/adobe/marketing/mobile/edge/identity/IdentityItemTests.java
@@ -13,6 +13,7 @@ package com.adobe.marketing.mobile.edge.identity;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
@@ -36,12 +37,23 @@ public class IdentityItemTests {
 	}
 
 	@Test(expected = IllegalArgumentException.class)
-	public void testIdentityItem_toObjectMap_missingId() {
-		// setup
+	public void testIdentityItem_ctor1_nullId_throwsIllegalArgumentException() {
 		IdentityItem item = new IdentityItem(null, AuthenticatedState.AUTHENTICATED, true);
+	}
 
-		// test
-		Map<String, Object> data = item.toObjectMap();
+	@Test(expected = IllegalArgumentException.class)
+	public void testIdentityItem_ctor1_emptyId_throwIllegalArgumentException() {
+		IdentityItem item = new IdentityItem("", AuthenticatedState.AUTHENTICATED, true);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testIdentityItem_ctor2_nullId_throwsIllegalArgumentException() {
+		IdentityItem item = new IdentityItem((String) null);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testIdentityItem_ctor2_emptyId_throwIllegalArgumentException() {
+		IdentityItem item = new IdentityItem("");
 	}
 
 	@Test
@@ -105,6 +117,38 @@ public class IdentityItemTests {
 		assertEquals("test-id", item.getId());
 		assertEquals("loggedOut", item.getAuthenticatedState().getName());
 		assertEquals(false, item.isPrimary());
+	}
+
+	@Test
+	public void testIdentityItem_fromData_missingId_returnNull() {
+		// setup
+		Map<String, Object> map = new HashMap<>();
+		map.put("authenticatedState", "loggedOut");
+		map.put("primary", false);
+
+		assertNull(IdentityItem.fromData(map));
+	}
+
+	@Test
+	public void testIdentityItem_fromData_nullId_returnNull() {
+		// setup
+		Map<String, Object> map = new HashMap<>();
+		map.put("id", null);
+		map.put("authenticatedState", "loggedOut");
+		map.put("primary", false);
+
+		assertNull(IdentityItem.fromData(map));
+	}
+
+	@Test
+	public void testIdentityItem_fromData_emptyId_returnNull() {
+		// setup
+		Map<String, Object> map = new HashMap<>();
+		map.put("id", "");
+		map.put("authenticatedState", "loggedOut");
+		map.put("primary", false);
+
+		assertNull(IdentityItem.fromData(map));
 	}
 
 	@Test

--- a/code/edgeidentity/src/test/java/com/adobe/marketing/mobile/edge/identity/IdentityMapTests.java
+++ b/code/edgeidentity/src/test/java/com/adobe/marketing/mobile/edge/identity/IdentityMapTests.java
@@ -311,6 +311,83 @@ public class IdentityMapTests {
 	}
 
 	@Test
+	public void test_FromData_removesItem_emptyId() throws Exception {
+		// setup
+		final String jsonStr =
+			"{\n" +
+			"      \"identityMap\": {\n" +
+			"        \"ECID\": [\n" +
+			"          {\n" +
+			"            \"id\":randomECID,\n" +
+			"            \"authenticatedState\": \"ambiguous\",\n" +
+			"            \"primary\": true\n" +
+			"          }\n" +
+			"        ],\n" +
+			"        \"USERID\": [\n" +
+			"          {\n" +
+			"            \"id\":\"\",\n" +
+			"            \"authenticatedState\": \"authenticated\",\n" +
+			"            \"primary\": false\n" +
+			"          }\n" +
+			"        ]\n" +
+			"      }\n" +
+			"}";
+
+		final JSONObject jsonObject = new JSONObject(jsonStr);
+		final Map<String, Object> xdmData = JSONUtils.toMap(jsonObject);
+
+		// test
+		IdentityMap map = IdentityMap.fromXDMMap(xdmData);
+
+		// verify
+		Map<String, String> flattenedMap = IdentityTestUtil.flattenMap(map.asXDMMap(false));
+		assertEquals("randomECID", flattenedMap.get("identityMap.ECID[0].id"));
+		assertEquals("ambiguous", flattenedMap.get("identityMap.ECID[0].authenticatedState"));
+		assertEquals("true", flattenedMap.get("identityMap.ECID[0].primary"));
+		assertNull(flattenedMap.get("identityMap.USERID[0].id"));
+		assertNull(flattenedMap.get("identityMap.USERID[0].authenticatedState"));
+		assertNull(flattenedMap.get("identityMap.USERID[0].primary"));
+	}
+
+	@Test
+	public void test_FromData_removesItem_missingId() throws Exception {
+		// setup
+		final String jsonStr =
+			"{\n" +
+			"      \"identityMap\": {\n" +
+			"        \"ECID\": [\n" +
+			"          {\n" +
+			"            \"id\":randomECID,\n" +
+			"            \"authenticatedState\": \"ambiguous\",\n" +
+			"            \"primary\": true\n" +
+			"          }\n" +
+			"        ],\n" +
+			"        \"USERID\": [\n" +
+			"          {\n" +
+			"            \"authenticatedState\": \"authenticated\",\n" +
+			"            \"primary\": false\n" +
+			"          }\n" +
+			"        ]\n" +
+			"      }\n" +
+			"}";
+
+		final JSONObject jsonObject = new JSONObject(jsonStr);
+		final Map<String, Object> xdmData = JSONUtils.toMap(jsonObject);
+
+		// test
+		IdentityMap map = IdentityMap.fromXDMMap(xdmData);
+
+		// verify
+		Map<String, String> flattenedMap = IdentityTestUtil.flattenMap(map.asXDMMap(false));
+		assertEquals("randomECID", flattenedMap.get("identityMap.ECID[0].id"));
+		assertEquals("ambiguous", flattenedMap.get("identityMap.ECID[0].authenticatedState"));
+		assertEquals("true", flattenedMap.get("identityMap.ECID[0].primary"));
+		assertNull(flattenedMap.get("identityMap.USERID[0].id"));
+		assertNull(flattenedMap.get("identityMap.USERID[0].authenticatedState"));
+		assertNull(flattenedMap.get("identityMap.USERID[0].primary"));
+	}
+
+	@Test
 	public void testFromXDMMap_NullAndEmptyData() {
 		assertNull(IdentityMap.fromXDMMap(null));
 		assertNull(IdentityMap.fromXDMMap(new HashMap<String, Object>()));

--- a/code/edgeidentity/src/test/java/com/adobe/marketing/mobile/edge/identity/IdentityMapTests.java
+++ b/code/edgeidentity/src/test/java/com/adobe/marketing/mobile/edge/identity/IdentityMapTests.java
@@ -35,6 +35,14 @@ public class IdentityMapTests {
 	}
 
 	@Test
+	public void test_addItem_withEmptyID_notAdded() {
+		// test
+		IdentityMap map = new IdentityMap();
+		map.addItem(new IdentityItem(""), "location");
+		assertTrue(map.isEmpty());
+	}
+
+	@Test
 	public void test_AddItem_InvalidInputs() {
 		// test
 		IdentityMap map = new IdentityMap();

--- a/code/edgeidentity/src/test/java/com/adobe/marketing/mobile/edge/identity/IdentityPropertiesTests.java
+++ b/code/edgeidentity/src/test/java/com/adobe/marketing/mobile/edge/identity/IdentityPropertiesTests.java
@@ -175,6 +175,30 @@ public class IdentityPropertiesTests {
 		assertEquals(0, flattenMap(props.toXDMData(false)).size());
 	}
 
+	@Test
+	public void testConstruct_FromXDMData_removesInvalidIdentityItems() {
+		// setup, Items with null or empty ids are invalid
+		Map<String, Object> persistedIdentifiers = createXDMIdentityMap(
+			new TestItem("UserId", "secretID"),
+			new TestItem("InvalidEmpty", ""),
+			new TestItem("InvalidNull", null),
+			new TestECIDItem("primaryECID"),
+			new TestECIDItem("secondaryECID")
+		);
+
+		// test
+		IdentityProperties props = new IdentityProperties(persistedIdentifiers);
+
+		// verify
+		Map<String, String> flatMap = flattenMap(props.toXDMData(false));
+		assertEquals(9, flatMap.size()); // 3x3
+		assertEquals("primaryECID", props.getECID().toString());
+		assertEquals("secondaryECID", props.getECIDSecondary().toString());
+		assertEquals("secretID", flatMap.get("identityMap.UserId[0].id"));
+		assertNull(flatMap.get("identityMap.InvalidEmpty[0].id"));
+		assertNull(flatMap.get("identityMap.InvalidNull[0].id"));
+	}
+
 	// ======================================================================================================================
 	// Tests for method : setECID(final ECID newEcid)
 	// ======================================================================================================================


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Do not allow IdentityItems with empty ids.

- If an IdentityItem is created with an empty or null id, throw IllegalArgumentException from constructor.
- Add tests to validate reading JSON Identity Maps which contain items with null/empty ids are correctly removed when the IdentityMap object is created.

See Issue #100 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
