### PR TITLE
 Switch to use Charset.forName("UTF-8").name() in encoding

### DIFF
--- a/code/app/build.gradle
+++ b/code/app/build.gradle
@@ -65,7 +65,9 @@ dependencies {
 
     implementation "com.adobe.marketing.mobile:core:2.+"
     implementation 'com.adobe.marketing.mobile:identity:2.+'
-    implementation 'com.adobe.marketing.mobile:edgeconsent:2.+'
+    implementation ('com.adobe.marketing.mobile:edgeconsent:2.+') {
+        transitive = false
+    }
     implementation 'com.adobe.marketing.mobile:assurance:2.+'
     implementation ('com.adobe.marketing.mobile:edge:2.+') {
         transitive = false

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/URLUtils.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/URLUtils.java
@@ -57,6 +57,7 @@ class URLUtils {
 				urlFragment.append(URLEncoder.encode(theIdString, Charset.forName("UTF-8").name()));
 			}
 		} catch (UnsupportedEncodingException | IllegalArgumentException e) {
+			urlFragment.append("null");
 			Log.debug(LOG_TAG, LOG_SOURCE, String.format("Failed to encode urlVariable string: %s", e));
 		}
 		return urlFragment.toString();

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/URLUtils.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/URLUtils.java
@@ -17,7 +17,7 @@ import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.util.StringUtils;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 
 class URLUtils {
 
@@ -54,7 +54,7 @@ class URLUtils {
 				// No need to encode
 				urlFragment.append("null");
 			} else {
-				urlFragment.append(URLEncoder.encode(theIdString, StandardCharsets.UTF_8.toString()));
+				urlFragment.append(URLEncoder.encode(theIdString, Charset.forName("UTF-8").name()));
 			}
 		} catch (UnsupportedEncodingException e) {
 			Log.debug(LOG_TAG, LOG_SOURCE, String.format("Failed to encode urlVariable string: %s", e));

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/URLUtils.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/URLUtils.java
@@ -56,7 +56,7 @@ class URLUtils {
 			} else {
 				urlFragment.append(URLEncoder.encode(theIdString, Charset.forName("UTF-8").name()));
 			}
-		} catch (UnsupportedEncodingException e) {
+		} catch (UnsupportedEncodingException | IllegalArgumentException e) {
 			Log.debug(LOG_TAG, LOG_SOURCE, String.format("Failed to encode urlVariable string: %s", e));
 		}
 		return urlFragment.toString();


### PR DESCRIPTION
Switching to use  Charset.forName("UTF-8").name() to fix the Illegal Charset Name Exception on Android 6 (API 23).  (MOB-19119).

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
