### PR TITLE
Update Core dependency to 3.0.0 (non snapshot) version

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Integrate the Identity for Edge Network mobile extension into your app by follow
 
 **Open the project**
 
-To open and run the project, open the `code/settings.gradle` file in Android Studio.
+To open and run the project, open the `code/settings.gradle.kt` file in Android Studio.
 
 **Run the test app**
 

--- a/code/app/build.gradle.kts
+++ b/code/app/build.gradle.kts
@@ -69,18 +69,13 @@ dependencies {
     implementation("com.google.android.material:material:1.3.0")
     implementation(project(":edgeidentity"))
 
-    implementation("com.adobe.marketing.mobile:core:$mavenCoreVersion-SNAPSHOT")
-    implementation("com.adobe.marketing.mobile:identity:3.0.0-SNAPSHOT") {
-        exclude(group = "com.adobe.marketing.mobile", module = "core")
-    }
+    implementation("com.adobe.marketing.mobile:core:$mavenCoreVersion")
+    implementation("com.adobe.marketing.mobile:identity:3.0.0")
     implementation("com.adobe.marketing.mobile:edgeconsent:3.0.0-SNAPSHOT") {
         exclude(group = "com.adobe.marketing.mobile", module = "edge")
-        exclude(group = "com.adobe.marketing.mobile", module = "core")
-
     }
     implementation("com.adobe.marketing.mobile:assurance:2.+")
     implementation("com.adobe.marketing.mobile:edge:3.0.0-SNAPSHOT") {
-        exclude(group = "com.adobe.marketing.mobile", module = "core")
         exclude(group = "com.adobe.marketing.mobile", module = "edgeidentity")
     }
     implementation("androidx.core:core-ktx:1.3.2")

--- a/code/app/build.gradle.kts
+++ b/code/app/build.gradle.kts
@@ -74,7 +74,7 @@ dependencies {
     implementation("com.adobe.marketing.mobile:edgeconsent:3.0.0-SNAPSHOT") {
         exclude(group = "com.adobe.marketing.mobile", module = "edge")
     }
-    implementation("com.adobe.marketing.mobile:assurance:2.+")
+    implementation("com.adobe.marketing.mobile:assurance:3.0.0")
     implementation("com.adobe.marketing.mobile:edge:3.0.0-SNAPSHOT") {
         exclude(group = "com.adobe.marketing.mobile", module = "edgeidentity")
     }

--- a/code/edgeidentity/build.gradle.kts
+++ b/code/edgeidentity/build.gradle.kts
@@ -28,9 +28,7 @@ aepLibrary {
 }
 
 dependencies {
-    // TODO: Use 3.x versions for testing
-    // TODO: Remove -SNAPSHOT suffix after Core 3.0.0 is published
-    implementation("com.adobe.marketing.mobile:core:$mavenCoreVersion-SNAPSHOT")
+    implementation("com.adobe.marketing.mobile:core:$mavenCoreVersion")
  
     // testImplementation dependencies provided by aep-library:
     // MOCKITO_CORE, JSON, ANDROIDX_TEST_EXT_JUNIT
@@ -41,7 +39,7 @@ dependencies {
     // ANDROIDX_TEST_EXT_JUNIT, ESPRESSO_CORE
 
     androidTestImplementation ("com.fasterxml.jackson.core:jackson-databind:2.12.7")
-    androidTestImplementation("com.adobe.marketing.mobile:identity:$functionalTestIdentityVersion-SNAPSHOT")
+    androidTestImplementation("com.adobe.marketing.mobile:identity:$functionalTestIdentityVersion")
     {
         exclude(group = "com.adobe.marketing.mobile", module = "core")
     }

--- a/code/edgeidentity/build.gradle.kts
+++ b/code/edgeidentity/build.gradle.kts
@@ -40,7 +40,4 @@ dependencies {
 
     androidTestImplementation ("com.fasterxml.jackson.core:jackson-databind:2.12.7")
     androidTestImplementation("com.adobe.marketing.mobile:identity:$functionalTestIdentityVersion")
-    {
-        exclude(group = "com.adobe.marketing.mobile", module = "core")
-    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updating dependencies to non-snapshot versions of 3.0.0.

- Sets Core and Identity dependencies in edgeidentity module to non-snapshot versions
- Updates app module to use non-snapshot version of Core. However, as Edge Identity is released before Edge and Consent, the test app must still reference the 3.0.0-SNAPSHOT releases of these extensions.

Note, as Core 3.0.0 is not yet released, the CI build will fail.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
