### PR TITLE
Do not dispatch reset complete event as response event.

### DIFF
--- a/code/edgeidentity/src/androidTest/java/com/adobe/marketing/mobile/edge/identity/IdentityResetHandlingTest.java
+++ b/code/edgeidentity/src/androidTest/java/com/adobe/marketing/mobile/edge/identity/IdentityResetHandlingTest.java
@@ -21,7 +21,10 @@ import static com.adobe.marketing.mobile.util.TestHelper.registerExtensions;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
+import com.adobe.marketing.mobile.AdobeCallbackWithError;
+import com.adobe.marketing.mobile.AdobeError;
 import com.adobe.marketing.mobile.Event;
 import com.adobe.marketing.mobile.EventSource;
 import com.adobe.marketing.mobile.EventType;
@@ -32,6 +35,9 @@ import com.adobe.marketing.mobile.util.TestPersistenceHelper;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -110,5 +116,30 @@ public class IdentityResetHandlingTest {
 			persistedJson,
 			new ElementCount(3, Subtree) // 3 for ECID
 		);
+	}
+
+	@Test
+	public void testReset_resetCompleteDispatchedToListeners() throws Exception {
+		// Verify the reset complete event dispatched by Identity is listenable
+		final CountDownLatch latch = new CountDownLatch(1);
+		MobileCore.registerEventListener(
+			EventType.EDGE_IDENTITY,
+			EventSource.RESET_COMPLETE,
+			new AdobeCallbackWithError<Event>() {
+				@Override
+				public void fail(AdobeError adobeError) {
+					Assert.fail("Reset Complete event listener called fail: " + adobeError.toString());
+				}
+
+				@Override
+				public void call(Event event) {
+					latch.countDown();
+				}
+			}
+		);
+
+		MobileCore.resetIdentities();
+
+		assertTrue("Failed to receive reset complete event.", latch.await(1, TimeUnit.SECONDS));
 	}
 }

--- a/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityExtension.java
+++ b/code/edgeidentity/src/main/java/com/adobe/marketing/mobile/edge/identity/IdentityExtension.java
@@ -345,7 +345,7 @@ class IdentityExtension extends Extension {
 			EventType.EDGE_IDENTITY,
 			EventSource.RESET_COMPLETE
 		)
-			.inResponseToEvent(event)
+			.chainToParentEvent(event)
 			.build();
 
 		getApi().dispatch(responseEvent);


### PR DESCRIPTION

## Description

The reset complete event must be dispatched as its own event and not as a response event so it may be listened for by extensions other than the caller.
This fixes an injection added in version 2.0.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
